### PR TITLE
add LaTeX on MobileApp

### DIFF
--- a/mobileAppFrontend/app/(student)/exam/[examId].tsx
+++ b/mobileAppFrontend/app/(student)/exam/[examId].tsx
@@ -2,6 +2,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { router, useLocalSearchParams } from "expo-router";
 import { useEffect, useMemo, useState } from "react";
 import { Pressable, SafeAreaView, ScrollView, StyleSheet, Text, View } from "react-native";
+import { MathText } from "@/components/MathText";
 import { PrimaryButton } from "@/components/PrimaryButton";
 import { StatusCard } from "@/components/StatusCard";
 import { useAppData } from "@/data/app-data";
@@ -17,7 +18,7 @@ import {
   formatScheduledDate,
   formatScheduledTime,
   getExamEndTime,
-  getStudentExamHeader,
+  getStudentExamPresentation,
 } from "@/lib/student-exam";
 
 export default function ExamDetailScreen() {
@@ -28,6 +29,10 @@ export default function ExamDetailScreen() {
   const [hasReminder, setHasReminder] = useState(false);
   const [isReminderLoading, setIsReminderLoading] = useState(false);
   const exam = getExamById(examId);
+  const presentation = useMemo(
+    () => (exam ? getStudentExamPresentation(exam.subject) : null),
+    [exam],
+  );
   const reminderDate = useMemo(
     () => getExamReminderDate(exam?.scheduledDate, exam?.startTime),
     [exam?.scheduledDate, exam?.startTime],
@@ -118,8 +123,9 @@ export default function ExamDetailScreen() {
         ) : null}
 
         <View style={styles.card}>
-          <Text style={styles.subjectLabel}>{getStudentExamHeader(exam.subject, exam.title)}</Text>
-          <Text style={styles.description}>{exam.description}</Text>
+          <Text style={styles.subjectBadge}>{presentation?.subjectLabel}</Text>
+          <MathText value={exam.title} style={styles.subjectLabel} />
+          <MathText value={exam.description} style={styles.description} />
 
           <View style={styles.metaRow}>
             <View style={styles.metaChip}>
@@ -209,10 +215,16 @@ const styles = StyleSheet.create({
     ...shadows.card,
   },
   subjectLabel: {
+    marginTop: 6,
     fontFamily: fonts.display.semibold,
     fontSize: 25,
     lineHeight: 34,
     color: colors.textPrimary,
+  },
+  subjectBadge: {
+    fontFamily: fonts.sans.medium,
+    fontSize: 13,
+    color: colors.primary,
   },
   description: {
     marginTop: 12,

--- a/mobileAppFrontend/app/(student)/exam/[examId]/take.tsx
+++ b/mobileAppFrontend/app/(student)/exam/[examId]/take.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Alert, Pressable, ScrollView, StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useAppData } from "@/data/app-data";
+import { MathText } from "@/components/MathText";
 import { SecurityOverlay } from "@/components/SecurityOverlay";
 import { SecureText } from "@/components/SecureText";
 import { FullScreenLoader } from "@/components/FullScreenLoader";
@@ -278,7 +279,7 @@ export default function TakeExamScreen() {
       </View>
 
       <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
-        <SecureText style={styles.title}>{exam.title}</SecureText>
+        <MathText value={exam.title} style={styles.title} />
         <SecureText style={styles.subtitle}>
           Бүх асуулт нэг дор харагдана. Доош гүйлгээд хариулаад, дуусмагц шалгалтаа илгээнэ үү.
         </SecureText>
@@ -349,7 +350,7 @@ export default function TakeExamScreen() {
                 <SecureText style={styles.questionPoints}>1 оноо</SecureText>
               </View>
 
-              <SecureText style={styles.questionTitle}>{question.question}</SecureText>
+              <MathText value={question.question} style={styles.questionTitle} />
 
               <View style={styles.choiceList}>
                 {question.choices.map((choice) => {
@@ -364,9 +365,7 @@ export default function TakeExamScreen() {
                       <View style={[styles.radio, selected ? styles.radioSelected : null]}>
                         {selected ? <View style={styles.radioInner} /> : null}
                       </View>
-                      <SecureText style={styles.choiceText}>
-                        {choice.label}. {choice.text}
-                      </SecureText>
+                      <MathText value={`${choice.label}. ${choice.text}`} style={styles.choiceText} />
                     </Pressable>
                   );
                 })}

--- a/mobileAppFrontend/app/(student)/results/[submissionId].tsx
+++ b/mobileAppFrontend/app/(student)/results/[submissionId].tsx
@@ -1,6 +1,7 @@
 import { Ionicons } from "@expo/vector-icons";
 import { router, useLocalSearchParams } from "expo-router";
 import { Pressable, SafeAreaView, ScrollView, StyleSheet, Text, View } from "react-native";
+import { MathText } from "@/components/MathText";
 import { StatusCard } from "@/components/StatusCard";
 import { useAppData } from "@/data/app-data";
 import type { SubmissionAnswer } from "@/data/types";
@@ -56,7 +57,7 @@ export default function ResultDetailScreen() {
         </Pressable>
 
         <View style={styles.heroCard}>
-          <Text style={styles.heroTitle}>{detail.title}</Text>
+          <MathText value={detail.title} style={styles.heroTitle} />
           <Text style={styles.heroSubtitle}>
             {detail.correctAnswers}/{detail.questionCount} зөв · {detail.scorePercent}%
           </Text>
@@ -106,9 +107,7 @@ export default function ResultDetailScreen() {
         <View style={styles.answers}>
           {detail.answers.map((answer) => (
             <View key={answer.questionId} style={styles.answerCard}>
-              <Text style={styles.questionTitle}>
-                {answer.order}. {answer.question}
-              </Text>
+              <MathText value={`${answer.order}. ${answer.question}`} style={styles.questionTitle} />
 
               <View style={styles.choiceList}>
                 {answer.choices.map((choice) => {
@@ -144,7 +143,7 @@ export default function ResultDetailScreen() {
                           {choice.label}
                         </Text>
                       </View>
-                      <Text style={styles.choiceText}>{choice.text}</Text>
+                      <MathText value={choice.text} style={styles.choiceText} />
                     </View>
                   );
                 })}

--- a/mobileAppFrontend/package-lock.json
+++ b/mobileAppFrontend/package-lock.json
@@ -24,11 +24,13 @@
         "expo-splash-screen": "~31.0.13",
         "expo-status-bar": "~3.0.9",
         "expo-system-ui": "~6.0.9",
+        "katex": "^0.16.44",
         "react": "19.1.0",
         "react-native": "0.81.5",
         "react-native-get-random-values": "~1.11.0",
         "react-native-safe-area-context": "~5.6.0",
-        "react-native-screens": "~4.16.0"
+        "react-native-screens": "~4.16.0",
+        "react-native-webview": "^13.16.1"
       },
       "devDependencies": {
         "@types/react": "~19.1.0",
@@ -3775,7 +3777,7 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4825,7 +4827,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -6973,6 +6975,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.44",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.44.tgz",
+      "integrity": "sha512-EkxoDTk8ufHqHlf9QxGwcxeLkWRR3iOuYfRpfORgYfqc8s13bgb+YtRY59NK5ZpRaCwq1kqA6a5lpX8C/eLphQ==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -8420,26 +8447,6 @@
         "ws": "^7"
       }
     },
-    "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.4"
-      }
-    },
-    "node_modules/react-dom/node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
@@ -8566,6 +8573,32 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-webview": {
+      "version": "13.16.1",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.16.1.tgz",
+      "integrity": "sha512-If0eHhoEdOYDcHsX+xBFwHMbWBGK1BvGDQDQdVkwtSIXiq1uiqjkpWVP2uQ1as94J0CzvFE9PUNDuhiX0Z6ubw==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-webview/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/react-native/node_modules/@react-native/virtualized-lists": {
@@ -9713,7 +9746,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/mobileAppFrontend/package.json
+++ b/mobileAppFrontend/package.json
@@ -26,11 +26,13 @@
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",
     "expo-system-ui": "~6.0.9",
+    "katex": "^0.16.44",
     "react": "19.1.0",
     "react-native": "0.81.5",
     "react-native-get-random-values": "~1.11.0",
     "react-native-safe-area-context": "~5.6.0",
-    "react-native-screens": "~4.16.0"
+    "react-native-screens": "~4.16.0",
+    "react-native-webview": "^13.16.1"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",

--- a/mobileAppFrontend/src/components/MathText.tsx
+++ b/mobileAppFrontend/src/components/MathText.tsx
@@ -1,0 +1,111 @@
+import { useMemo, useState } from "react";
+import { StyleSheet, View, type StyleProp, type TextStyle, type ViewStyle } from "react-native";
+import WebView from "react-native-webview";
+import { SecureText } from "@/components/SecureText";
+import { buildMathHtml, hasMathMarkup } from "@/lib/math-render";
+
+function extractContainerStyle(style?: TextStyle): ViewStyle {
+  if (!style) {
+    return {};
+  }
+
+  return {
+    margin: style.margin,
+    marginTop: style.marginTop,
+    marginRight: style.marginRight,
+    marginBottom: style.marginBottom,
+    marginLeft: style.marginLeft,
+    marginHorizontal: style.marginHorizontal,
+    marginVertical: style.marginVertical,
+    flex: style.flex,
+    flexBasis: style.flexBasis,
+    flexGrow: style.flexGrow,
+    flexShrink: style.flexShrink,
+    alignSelf: style.alignSelf,
+    width: style.width,
+    minWidth: style.minWidth,
+    maxWidth: style.maxWidth,
+  };
+}
+
+function normalizeTextStyle(style?: TextStyle): TextStyle | undefined {
+  if (!style) {
+    return undefined;
+  }
+
+  return {
+    fontSize: style.fontSize,
+    lineHeight: style.lineHeight,
+    color: style.color,
+    fontFamily: style.fontFamily,
+    textAlign: style.textAlign,
+  };
+}
+
+export function MathText({
+  value,
+  style,
+  containerStyle,
+}: {
+  value: string;
+  style?: StyleProp<TextStyle>;
+  containerStyle?: StyleProp<ViewStyle>;
+}) {
+  const flattenedStyle = StyleSheet.flatten(style);
+  const [contentHeight, setContentHeight] = useState(
+    typeof flattenedStyle?.lineHeight === "number"
+      ? flattenedStyle.lineHeight + 4
+      : typeof flattenedStyle?.fontSize === "number"
+        ? Math.round(flattenedStyle.fontSize * 1.6)
+        : 28,
+  );
+  const [hasRenderError, setHasRenderError] = useState(false);
+  const isMath = useMemo(() => hasMathMarkup(value), [value]);
+  const html = useMemo(
+    () => buildMathHtml(value, normalizeTextStyle(flattenedStyle)),
+    [flattenedStyle, value],
+  );
+
+  if (!isMath || hasRenderError) {
+    return <SecureText style={style}>{value}</SecureText>;
+  }
+
+  return (
+    <View style={[extractContainerStyle(flattenedStyle), containerStyle]}>
+      <View pointerEvents="none" style={[styles.webviewWrap, { minHeight: contentHeight }]}>
+        <WebView
+          source={{ html }}
+          originWhitelist={["*"]}
+          scrollEnabled={false}
+          bounces={false}
+          javaScriptEnabled
+          automaticallyAdjustContentInsets={false}
+          onError={() => setHasRenderError(true)}
+          onMessage={(event) => {
+            const nextHeight = Number(event.nativeEvent.data);
+
+            if (!Number.isFinite(nextHeight) || nextHeight <= 0) {
+              return;
+            }
+
+            setContentHeight((currentHeight) =>
+              Math.abs(currentHeight - nextHeight) > 1 ? Math.ceil(nextHeight) : currentHeight,
+            );
+          }}
+          style={[styles.webview, { height: contentHeight }]}
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  webviewWrap: {
+    width: "100%",
+    backgroundColor: "transparent",
+  },
+  webview: {
+    width: "100%",
+    backgroundColor: "transparent",
+  },
+});

--- a/mobileAppFrontend/src/components/StudentExamCard.tsx
+++ b/mobileAppFrontend/src/components/StudentExamCard.tsx
@@ -1,5 +1,6 @@
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { Pressable, StyleSheet, Text, View } from "react-native";
+import { MathText } from "@/components/MathText";
 import { getStudentExamPresentation } from "@/lib/student-exam";
 import { colors, fonts, shadows } from "@/lib/theme";
 
@@ -43,10 +44,10 @@ export function StudentExamCard({
         />
       </View>
 
-      <Text style={styles.title}>
-        <Text style={styles.subject}>{presentation.subjectLabel}</Text>{" "}
-        <Text style={styles.topic}>/{title}/</Text>
-      </Text>
+      <View style={styles.titleBlock}>
+        <Text style={styles.subject}>{presentation.subjectLabel}</Text>
+        <MathText value={`/${title}/`} style={styles.topic} />
+      </View>
       <Text style={styles.grade}>{grade}</Text>
 
       <View style={styles.metaRow}>
@@ -85,17 +86,20 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     borderRadius: 18,
   },
-  title: {
+  titleBlock: {
     marginTop: 14,
-    fontSize: 21,
-    lineHeight: 28,
   },
   subject: {
     fontFamily: fonts.display.semibold,
+    fontSize: 21,
+    lineHeight: 28,
     color: colors.textPrimary,
   },
   topic: {
+    marginTop: 2,
     fontFamily: fonts.sans.regular,
+    fontSize: 21,
+    lineHeight: 28,
     color: colors.textMuted,
   },
   grade: {

--- a/mobileAppFrontend/src/lib/math-render.ts
+++ b/mobileAppFrontend/src/lib/math-render.ts
@@ -1,0 +1,177 @@
+import katex from "katex";
+import type { TextStyle } from "react-native";
+
+const MATH_PATTERN = /\$\$([\s\S]+?)\$\$|\$([^$]+?)\$/g;
+const KATEX_STYLESHEET_URL = `https://cdn.jsdelivr.net/npm/katex@${katex.version}/dist/katex.min.css`;
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function getCssFontWeight(fontFamily?: string) {
+  if (!fontFamily) {
+    return 400;
+  }
+
+  const normalized = fontFamily.toLowerCase();
+
+  if (normalized.includes("bold")) {
+    return 700;
+  }
+
+  if (normalized.includes("semibold")) {
+    return 600;
+  }
+
+  if (normalized.includes("medium")) {
+    return 500;
+  }
+
+  return 400;
+}
+
+function renderFormula(latex: string, displayMode: boolean) {
+  return katex.renderToString(latex.trim(), {
+    displayMode,
+    throwOnError: false,
+    strict: "ignore",
+  });
+}
+
+export function hasMathMarkup(value: string) {
+  MATH_PATTERN.lastIndex = 0;
+  return MATH_PATTERN.test(value);
+}
+
+export function buildMathHtml(value: string, style?: TextStyle) {
+  const fontSize = style?.fontSize ?? 16;
+  const lineHeight =
+    typeof style?.lineHeight === "number" ? style.lineHeight : Math.round(fontSize * 1.45);
+  const textColor = typeof style?.color === "string" ? style.color : "#1F1B2D";
+  const textAlign = typeof style?.textAlign === "string" ? style.textAlign : "left";
+  const fontWeight = getCssFontWeight(style?.fontFamily);
+
+  MATH_PATTERN.lastIndex = 0;
+
+  let lastIndex = 0;
+  const parts: string[] = [];
+
+  for (const match of value.matchAll(MATH_PATTERN)) {
+    const [fullMatch, blockLatex, inlineLatex] = match;
+    const matchIndex = match.index ?? 0;
+    const leadingText = value.slice(lastIndex, matchIndex);
+
+    if (leadingText) {
+      parts.push(escapeHtml(leadingText));
+    }
+
+    parts.push(
+      blockLatex
+        ? `<div class="pq-block">${renderFormula(blockLatex, true)}</div>`
+        : `<span class="pq-inline">${renderFormula(inlineLatex ?? "", false)}</span>`,
+    );
+
+    lastIndex = matchIndex + fullMatch.length;
+  }
+
+  const trailingText = value.slice(lastIndex);
+  if (trailingText) {
+    parts.push(escapeHtml(trailingText));
+  }
+
+  return `<!DOCTYPE html>
+<html lang="mn">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+    <link rel="stylesheet" href="${KATEX_STYLESHEET_URL}" />
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        background: transparent;
+      }
+
+      body {
+        overflow: hidden;
+        color: ${textColor};
+        font-size: ${fontSize}px;
+        line-height: ${lineHeight}px;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font-weight: ${fontWeight};
+        text-align: ${textAlign};
+        -webkit-user-select: none;
+        user-select: none;
+        -webkit-touch-callout: none;
+        word-break: break-word;
+      }
+
+      .pq-root {
+        white-space: pre-wrap;
+      }
+
+      .pq-inline {
+        display: inline;
+      }
+
+      .pq-block {
+        margin: 8px 0;
+      }
+
+      .katex-display {
+        margin: 0.35em 0;
+        overflow-x: auto;
+        overflow-y: hidden;
+        padding: 2px 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="pq-root">${parts.join("")}</div>
+    <script>
+      (function () {
+        var lastHeight = 0;
+
+        function postHeight() {
+          var nextHeight = Math.max(
+            document.documentElement ? document.documentElement.scrollHeight : 0,
+            document.body ? document.body.scrollHeight : 0
+          );
+
+          if (!nextHeight || Math.abs(nextHeight - lastHeight) < 1) {
+            return;
+          }
+
+          lastHeight = nextHeight;
+
+          if (window.ReactNativeWebView) {
+            window.ReactNativeWebView.postMessage(String(Math.ceil(nextHeight)));
+          }
+        }
+
+        var resizeObserver = typeof ResizeObserver !== "undefined"
+          ? new ResizeObserver(postHeight)
+          : null;
+
+        if (resizeObserver && document.body) {
+          resizeObserver.observe(document.body);
+        }
+
+        window.addEventListener("load", postHeight);
+        if (document.fonts && document.fonts.ready) {
+          document.fonts.ready.then(postHeight);
+        }
+
+        requestAnimationFrame(postHeight);
+        setTimeout(postHeight, 60);
+        setTimeout(postHeight, 250);
+      })();
+    </script>
+  </body>
+</html>`;
+}


### PR DESCRIPTION
## Summary
Added LaTeX math rendering support to the student mobile app so `$...$` and `$$...$$` formulas display correctly on iOS exam screens.

## Changes
- Added a shared mobile math rendering component
- Added formula parsing/rendering utility for inline and block LaTeX
- Render formulas on:
  - exam detail screen
  - exam taking screen
  - result review screen
  - exam cards where titles may include formulas
- Kept normal plain text rendering fast when no math markup is present
- Added required mobile dependencies for math rendering

## Files
- `mobileAppFrontend/src/components/MathText.tsx`
- `mobileAppFrontend/src/lib/math-render.ts`
- `mobileAppFrontend/app/(student)/exam/[examId].tsx`
- `mobileAppFrontend/app/(student)/exam/[examId]/take.tsx`
- `mobileAppFrontend/app/(student)/results/[submissionId].tsx`
- `mobileAppFrontend/src/components/StudentExamCard.tsx`
- `mobileAppFrontend/package.json`

## Notes
- Supports inline `$...$` and block `$$...$$` formulas
- Falls back to normal text rendering if no formula markup exists
- Current implementation uses KaTeX rendering inside mobile WebView
- KaTeX stylesheet is currently loaded from CDN, so best rendering requires network access

## Validation
- `cd mobileAppFrontend && npm run typecheck` passed
- `cd mobileAppFrontend && npx expo prebuild --platform ios --no-install` passed
