### PR TITLE
add authoritative mobile exam session integrity backend

### DIFF
--- a/cold-king-fc65/migrations/0004_student_exam_sessions.sql
+++ b/cold-king-fc65/migrations/0004_student_exam_sessions.sql
@@ -1,0 +1,18 @@
+CREATE TABLE `student_exam_sessions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`studentId` text NOT NULL,
+	`examId` text NOT NULL,
+	`sessionId` text NOT NULL,
+	`deviceId` text NOT NULL,
+	`startedAt` integer NOT NULL,
+	`lastHeartbeatAt` integer NOT NULL,
+	`lastActionAt` integer NOT NULL,
+	`createdAt` integer NOT NULL,
+	`updatedAt` integer NOT NULL,
+	FOREIGN KEY (`studentId`) REFERENCES `students`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`examId`) REFERENCES `exams`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `student_exam_sessions_student_idx` ON `student_exam_sessions` (`studentId`);
+--> statement-breakpoint
+CREATE INDEX `student_exam_sessions_exam_idx` ON `student_exam_sessions` (`examId`);

--- a/cold-king-fc65/src/db/client.ts
+++ b/cold-king-fc65/src/db/client.ts
@@ -4,6 +4,7 @@ import { drizzle } from "drizzle-orm/d1";
 import * as examSchema from "./schemas/exam.schema";
 import * as questionSchema from "./schemas/question.schema";
 import * as studentExamAnswerSchema from "./schemas/student-exam-answer.schema";
+import * as studentExamSessionSchema from "./schemas/student-exam-session.schema";
 import * as studentExamSubmissionSchema from "./schemas/student-exam-submission.schema";
 import * as studentSchema from "./schemas/student.schema";
 import * as teacherSchema from "./schemas/teacher.schema";
@@ -14,6 +15,7 @@ const schema = {
 	...examSchema,
 	...questionSchema,
 	...studentExamAnswerSchema,
+	...studentExamSessionSchema,
 	...studentExamSubmissionSchema,
 	...studentSchema,
 	...teacherSchema,

--- a/cold-king-fc65/src/db/schemas/student-exam-session.schema.ts
+++ b/cold-king-fc65/src/db/schemas/student-exam-session.schema.ts
@@ -1,0 +1,20 @@
+import { int, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { exams } from "./exam.schema";
+import { students } from "./student.schema";
+
+export const studentExamSessions = sqliteTable("student_exam_sessions", {
+	id: text().primaryKey(),
+	studentId: text()
+		.notNull()
+		.references(() => students.id, { onDelete: "cascade" }),
+	examId: text()
+		.notNull()
+		.references(() => exams.id, { onDelete: "cascade" }),
+	sessionId: text().notNull(),
+	deviceId: text().notNull(),
+	startedAt: int().notNull(),
+	lastHeartbeatAt: int().notNull(),
+	lastActionAt: int().notNull(),
+	createdAt: int().notNull(),
+	updatedAt: int().notNull(),
+});

--- a/cold-king-fc65/src/index.ts
+++ b/cold-king-fc65/src/index.ts
@@ -1,9 +1,42 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { eq } from "drizzle-orm";
 import { getCorsOrigins, type WorkerBindings } from "./config/runtime";
-import { getRequestAuth, yoga } from "./server";
+import { getDb } from "./db/client";
+import { studentExamSessions } from "./db/schemas/student-exam-session.schema";
+import { getRequestAuth, getResolvedRequestAuth, yoga } from "./server";
 
 const app = new Hono<{ Bindings: WorkerBindings }>();
+const SESSION_INTEGRITY_PATH = "/session-integrity";
+
+type SessionIntegrityAction = {
+	id: string;
+	type: "start" | "heartbeat" | "stop";
+	userId: string;
+	examId: string;
+	deviceId: string;
+	sessionId: string;
+	timestamp: number;
+};
+
+function isSessionIntegrityAction(value: unknown): value is SessionIntegrityAction {
+	if (!value || typeof value !== "object") {
+		return false;
+	}
+
+	const action = value as Record<string, unknown>;
+
+	return (
+		typeof action.id === "string" &&
+		(action.type === "start" || action.type === "heartbeat" || action.type === "stop") &&
+		typeof action.userId === "string" &&
+		typeof action.examId === "string" &&
+		typeof action.deviceId === "string" &&
+		typeof action.sessionId === "string" &&
+		typeof action.timestamp === "number" &&
+		Number.isFinite(action.timestamp)
+	);
+}
 
 function sanitizePathSegment(value: string) {
 	return value.replace(/[^a-zA-Z0-9._-]/g, "_");
@@ -29,11 +62,121 @@ app.use("/uploads/*", (c, next) =>
 	})(c, next),
 );
 
+app.use(SESSION_INTEGRITY_PATH, (c, next) =>
+	cors({
+		origin: getCorsOrigins(c.env),
+		allowHeaders: [
+			"Content-Type",
+			"Authorization",
+			"x-mobile-demo-key",
+			"x-mobile-student-email",
+			"x-mobile-student-invite-code",
+		],
+		allowMethods: ["POST", "OPTIONS"],
+		credentials: true,
+	})(c, next),
+);
+
 app.all("/graphql", (c) =>
 	yoga.fetch(c.req.raw, {
 		env: c.env,
 	}),
 );
+
+app.post(SESSION_INTEGRITY_PATH, async (c) => {
+	const db = getDb(c.env);
+	const auth = await getResolvedRequestAuth(c.req.raw, c.env, db);
+
+	if (!auth.isAuthenticated || !auth.userId) {
+		return c.json({ error: "Unauthorized" }, 401);
+	}
+
+	let body: unknown;
+
+	try {
+		body = await c.req.json();
+	} catch {
+		return c.json({ error: "Invalid JSON body." }, 400);
+	}
+
+	if (!isSessionIntegrityAction(body)) {
+		return c.json({ error: "Invalid session payload." }, 400);
+	}
+
+	const action = body;
+
+	if (action.userId !== auth.userId) {
+		return c.json({ error: "Session user mismatch." }, 403);
+	}
+
+	const sessionKey = `${action.userId}::${action.examId}`;
+	const now = Date.now();
+	const existing = await db
+		.select()
+		.from(studentExamSessions)
+		.where(eq(studentExamSessions.id, sessionKey))
+		.get();
+
+	if (!existing) {
+		if (action.type === "stop") {
+			return c.json({ status: "ok" as const });
+		}
+
+		await db.insert(studentExamSessions).values({
+			id: sessionKey,
+			studentId: action.userId,
+			examId: action.examId,
+			sessionId: action.sessionId,
+			deviceId: action.deviceId,
+			startedAt: action.timestamp,
+			lastHeartbeatAt: action.timestamp,
+			lastActionAt: action.timestamp,
+			createdAt: now,
+			updatedAt: now,
+		});
+
+		return c.json({ status: "ok" as const });
+	}
+
+	const isSameSession =
+		existing.sessionId === action.sessionId && existing.deviceId === action.deviceId;
+
+	if (!isSameSession) {
+		if (action.type !== "start" || action.timestamp <= existing.lastActionAt) {
+			return c.json({ status: "replaced_by_other_device" as const });
+		}
+
+		await db
+			.update(studentExamSessions)
+			.set({
+				sessionId: action.sessionId,
+				deviceId: action.deviceId,
+				startedAt: action.timestamp,
+				lastHeartbeatAt: action.timestamp,
+				lastActionAt: action.timestamp,
+				updatedAt: now,
+			})
+			.where(eq(studentExamSessions.id, sessionKey));
+
+		return c.json({ status: "ok" as const });
+	}
+
+	if (action.type === "stop") {
+		await db.delete(studentExamSessions).where(eq(studentExamSessions.id, sessionKey));
+		return c.json({ status: "ok" as const });
+	}
+
+	await db
+		.update(studentExamSessions)
+		.set({
+			lastHeartbeatAt: action.timestamp,
+			lastActionAt: action.timestamp,
+			updatedAt: now,
+		})
+		.where(eq(studentExamSessions.id, sessionKey));
+
+	return c.json({ status: "ok" as const });
+});
 
 app.post("/uploads/question-image", async (c) => {
 	if (!c.env.exam_media) {

--- a/cold-king-fc65/src/server.ts
+++ b/cold-king-fc65/src/server.ts
@@ -149,6 +149,20 @@ async function getMobileDemoRequestAuth(
 	};
 }
 
+export async function getResolvedRequestAuth(
+	request: Request,
+	env: WorkerBindings,
+	db = getDb(env),
+): Promise<GraphQLContext["auth"]> {
+	const requestAuth = await getRequestAuth(request, env);
+
+	if (requestAuth.isAuthenticated) {
+		return requestAuth;
+	}
+
+	return (await getMobileDemoRequestAuth(request, env, db)) ?? requestAuth;
+}
+
 export const yoga = createYoga<{ env: WorkerBindings }, GraphQLContext>({
 	schema: createSchema({
 		typeDefs,
@@ -156,11 +170,7 @@ export const yoga = createYoga<{ env: WorkerBindings }, GraphQLContext>({
 	}),
 	context: async ({ request, env }) => {
 		const db = getDb(env);
-		const requestAuth = await getRequestAuth(request, env);
-		const auth =
-			requestAuth.isAuthenticated
-				? requestAuth
-				: (await getMobileDemoRequestAuth(request, env, db)) ?? requestAuth;
+		const auth = await getResolvedRequestAuth(request, env, db);
 
 		return {
 			env,

--- a/mobileAppFrontend/app/(student)/(tabs)/index.tsx
+++ b/mobileAppFrontend/app/(student)/(tabs)/index.tsx
@@ -1,6 +1,7 @@
 import { router } from "expo-router";
 import { useState } from "react";
-import { RefreshControl, SafeAreaView, ScrollView, StyleSheet, Text, View } from "react-native";
+import { RefreshControl, ScrollView, StyleSheet, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { EmptyState } from "@/components/EmptyState";
 import { StatusCard } from "@/components/StatusCard";
 import { StudentExamCard } from "@/components/StudentExamCard";
@@ -22,7 +23,7 @@ export default function StudentHomeScreen() {
   };
 
   return (
-    <SafeAreaView style={styles.page}>
+    <SafeAreaView edges={["top", "left", "right"]} style={styles.page}>
       <ScrollView
         contentContainerStyle={styles.content}
         refreshControl={
@@ -63,7 +64,7 @@ export default function StudentHomeScreen() {
                 title={exam.title}
                 grade={exam.grade}
                 duration={exam.duration}
-                questionCount={exam.questions.length}
+                questionCount={exam.questionCount}
                 scheduledDate={exam.scheduledDate}
                 startTime={exam.startTime}
                 onPress={() => router.push(`/(student)/exam/${exam.id}`)}

--- a/mobileAppFrontend/app/(student)/(tabs)/profile.tsx
+++ b/mobileAppFrontend/app/(student)/(tabs)/profile.tsx
@@ -1,4 +1,5 @@
-import { Alert, SafeAreaView, ScrollView, StyleSheet, Text, View } from "react-native";
+import { Alert, ScrollView, StyleSheet, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { PrimaryButton } from "@/components/PrimaryButton";
 import { StatusCard } from "@/components/StatusCard";
 import { useAppData } from "@/data/app-data";
@@ -16,10 +17,15 @@ function getInitials(fullName: string) {
 }
 
 export default function ProfileScreen() {
-  const { student, submissions, availableExams, resetData } = useAppData();
+  const { student, submissions, availableExams, isRemoteData, resetData } = useAppData();
 
   const handleReset = () => {
-    Alert.alert("Өгөгдөл цэвэрлэх", "Өгсөн шалгалтын төхөөрөмж дээр хадгалсан үр дүнг цэвэрлэх үү?", [
+    Alert.alert(
+      isRemoteData ? "Өгөгдөл шинэчлэх" : "Өгөгдөл цэвэрлэх",
+      isRemoteData
+        ? "Backend-ээс хамгийн сүүлийн өгөгдлийг дахин ачаалах уу?"
+        : "Өгсөн шалгалтын төхөөрөмж дээр хадгалсан үр дүнг цэвэрлэх үү?",
+      [
       {
         text: "Болих",
         style: "cancel",
@@ -31,11 +37,12 @@ export default function ProfileScreen() {
           resetData();
         },
       },
-    ]);
+      ],
+    );
   };
 
   return (
-    <SafeAreaView style={styles.page}>
+    <SafeAreaView edges={["top", "left", "right"]} style={styles.page}>
       <ScrollView contentContainerStyle={styles.content}>
         <View style={styles.profileCard}>
           <View style={styles.avatar}>
@@ -64,10 +71,18 @@ export default function ProfileScreen() {
 
         <StatusCard
           tone="info"
-          message="Энэ хэсэг одоогоор төхөөрөмж дээрх туршилтын өгөгдлөөр ажиллаж байна. Жинхэнэ нэвтрэлт холбогдоход энд профайлын бодит өгөгдөл орж ирнэ."
+          message={
+            isRemoteData
+              ? "Энэ профайлын мэдээлэл одоогоор backend-ээс ачаалагдаж байна."
+              : "Энэ хэсэг одоогоор төхөөрөмж дээрх туршилтын өгөгдлөөр ажиллаж байна."
+          }
         />
 
-        <PrimaryButton label="Үр дүн цэвэрлэх" onPress={handleReset} variant="secondary" />
+        <PrimaryButton
+          label={isRemoteData ? "Өгөгдөл шинэчлэх" : "Үр дүн цэвэрлэх"}
+          onPress={handleReset}
+          variant="secondary"
+        />
       </ScrollView>
     </SafeAreaView>
   );

--- a/mobileAppFrontend/app/(student)/(tabs)/results.tsx
+++ b/mobileAppFrontend/app/(student)/(tabs)/results.tsx
@@ -1,5 +1,6 @@
 import { router } from "expo-router";
-import { SafeAreaView, ScrollView, StyleSheet, Text, View } from "react-native";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { EmptyState } from "@/components/EmptyState";
 import { StudentExamCard } from "@/components/StudentExamCard";
 import { useAppData } from "@/data/app-data";
@@ -10,7 +11,7 @@ export default function ResultsScreen() {
   const { submissions } = useAppData();
 
   return (
-    <SafeAreaView style={styles.page}>
+    <SafeAreaView edges={["top", "left", "right"]} style={styles.page}>
       <ScrollView contentContainerStyle={styles.content}>
         <View style={styles.statsCard}>
           <Text style={styles.statsValue}>{submissions.length}</Text>

--- a/mobileAppFrontend/app/(student)/exam/[examId].tsx
+++ b/mobileAppFrontend/app/(student)/exam/[examId].tsx
@@ -1,7 +1,8 @@
 import { Ionicons } from "@expo/vector-icons";
 import { router, useLocalSearchParams } from "expo-router";
 import { useEffect, useMemo, useState } from "react";
-import { Pressable, SafeAreaView, ScrollView, StyleSheet, Text, View } from "react-native";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { MathText } from "@/components/MathText";
 import { PrimaryButton } from "@/components/PrimaryButton";
 import { StatusCard } from "@/components/StatusCard";
@@ -24,10 +25,12 @@ import {
 export default function ExamDetailScreen() {
   const params = useLocalSearchParams<{ examId: string }>();
   const examId = typeof params.examId === "string" ? params.examId : "";
-  const { getExamById } = useAppData();
+  const { ensureExamLoaded, getExamById } = useAppData();
   const [reminderMessage, setReminderMessage] = useState("");
   const [hasReminder, setHasReminder] = useState(false);
   const [isReminderLoading, setIsReminderLoading] = useState(false);
+  const [isExamLoading, setIsExamLoading] = useState(false);
+  const [examLoadError, setExamLoadError] = useState("");
   const exam = getExamById(examId);
   const presentation = useMemo(
     () => (exam ? getStudentExamPresentation(exam.subject) : null),
@@ -61,6 +64,34 @@ export default function ExamDetailScreen() {
     };
   }, [exam]);
 
+  useEffect(() => {
+    if (!exam || exam.questions.length > 0 || exam.questionCount === 0) {
+      return;
+    }
+
+    let cancelled = false;
+    setIsExamLoading(true);
+    setExamLoadError("");
+
+    void ensureExamLoaded(exam.id)
+      .catch((caughtError) => {
+        if (!cancelled) {
+          setExamLoadError(
+            caughtError instanceof Error ? caughtError.message : "Шалгалтын дэлгэрэнгүйг ачаалж чадсангүй.",
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsExamLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [ensureExamLoaded, exam]);
+
   const handleReminderPress = async () => {
     if (!exam) {
       return;
@@ -93,9 +124,38 @@ export default function ExamDetailScreen() {
     }
   };
 
+  const handleStartPress = async () => {
+    if (!exam) {
+      return;
+    }
+
+    if (exam.questionCount > 0 && exam.questions.length === 0) {
+      setIsExamLoading(true);
+      setExamLoadError("");
+
+      try {
+        const loadedExam = await ensureExamLoaded(exam.id);
+
+        if (!loadedExam || loadedExam.questionCount === 0) {
+          setExamLoadError("Шалгалтын асуултыг ачаалж чадсангүй.");
+          return;
+        }
+      } catch (caughtError) {
+        setExamLoadError(
+          caughtError instanceof Error ? caughtError.message : "Шалгалтын асуултыг ачаалж чадсангүй.",
+        );
+        return;
+      } finally {
+        setIsExamLoading(false);
+      }
+    }
+
+    router.push(`/(student)/exam/${exam.id}/take`);
+  };
+
   if (!exam) {
     return (
-      <SafeAreaView style={styles.page}>
+      <SafeAreaView edges={["top", "left", "right"]} style={styles.page}>
         <View style={styles.content}>
           <Pressable style={styles.backButton} onPress={() => router.back()}>
             <Ionicons name="chevron-back" size={18} color={colors.textPrimary} />
@@ -108,7 +168,7 @@ export default function ExamDetailScreen() {
   }
 
   return (
-    <SafeAreaView style={styles.page}>
+    <SafeAreaView edges={["top", "left", "right"]} style={styles.page}>
       <ScrollView contentContainerStyle={styles.content}>
         <Pressable style={styles.backButton} onPress={() => router.back()}>
           <Ionicons name="chevron-back" size={18} color={colors.textPrimary} />
@@ -121,6 +181,7 @@ export default function ExamDetailScreen() {
             message={reminderMessage}
           />
         ) : null}
+        {examLoadError ? <StatusCard tone="error" message={examLoadError} /> : null}
 
         <View style={styles.card}>
           <Text style={styles.subjectBadge}>{presentation?.subjectLabel}</Text>
@@ -134,7 +195,7 @@ export default function ExamDetailScreen() {
             </View>
             <View style={styles.metaChip}>
               <Ionicons name="document-text-outline" size={14} color={colors.textSecondary} />
-              <Text style={styles.metaChipText}>{exam.questions.length} даалгавар</Text>
+              <Text style={styles.metaChipText}>{exam.questionCount} даалгавар</Text>
             </View>
           </View>
 
@@ -177,8 +238,9 @@ export default function ExamDetailScreen() {
           />
           <PrimaryButton
             label="Эхлэх"
-            onPress={() => router.push(`/(student)/exam/${exam.id}/take`)}
-            disabled={exam.questions.length === 0}
+            onPress={() => void handleStartPress()}
+            disabled={isExamLoading || exam.questionCount === 0}
+            loading={isExamLoading}
           />
         </View>
       </ScrollView>

--- a/mobileAppFrontend/app/(student)/exam/[examId]/take.tsx
+++ b/mobileAppFrontend/app/(student)/exam/[examId]/take.tsx
@@ -26,12 +26,14 @@ function getRemainingSeconds(durationMinutes: number, startedAt: number) {
 export default function TakeExamScreen() {
   const params = useLocalSearchParams<{ examId: string }>();
   const examId = typeof params.examId === "string" ? params.examId : "";
-  const { getExamById, submitExam, student } = useAppData();
+  const { ensureExamLoaded, getExamById, submitExam, student } = useAppData();
   const [secondsLeft, setSecondsLeft] = useState(0);
   const [answers, setAnswers] = useState<Record<string, StudentAnswerDraft>>({});
   const [submitError, setSubmitError] = useState("");
   const [startedAt, setStartedAt] = useState<number | null>(null);
   const [isRestoring, setIsRestoring] = useState(true);
+  const [isExamLoading, setIsExamLoading] = useState(false);
+  const [examLoadError, setExamLoadError] = useState("");
   const [submitLoading, setSubmitLoading] = useState(false);
   const autoSubmittedRef = useRef(false);
   const answersRef = useRef<Record<string, StudentAnswerDraft>>({});
@@ -63,7 +65,7 @@ export default function TakeExamScreen() {
     faceStatus,
     nativeMonitoringAvailable,
   } = useExamIntegrity({
-    userId: student.email,
+    userId: student.id,
     examId,
     onAutoSubmit: async (reason) => {
       await submitExamRef.current(
@@ -81,7 +83,35 @@ export default function TakeExamScreen() {
   }, [startedAt]);
 
   useEffect(() => {
-    if (!exam) {
+    if (!exam || exam.questions.length > 0 || exam.questionCount === 0) {
+      return;
+    }
+
+    let cancelled = false;
+    setIsExamLoading(true);
+    setExamLoadError("");
+
+    void ensureExamLoaded(exam.id)
+      .catch((caughtError) => {
+        if (!cancelled) {
+          setExamLoadError(
+            caughtError instanceof Error ? caughtError.message : "Шалгалтын асуултыг ачаалж чадсангүй.",
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsExamLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [ensureExamLoaded, exam]);
+
+  useEffect(() => {
+    if (!exam || exam.questions.length === 0 && exam.questionCount > 0) {
       return;
     }
 
@@ -227,8 +257,18 @@ export default function TakeExamScreen() {
     void submitExamRef.current("manual");
   };
 
-  if (isRestoring) {
+  if (isExamLoading || isRestoring) {
     return <FullScreenLoader label="Шалгалтын явцыг бэлдэж байна..." />;
+  }
+
+  if (examLoadError) {
+    return (
+      <SafeAreaView style={styles.page}>
+        <View style={styles.content}>
+          <StatusCard tone="error" message={examLoadError} />
+        </View>
+      </SafeAreaView>
+    );
   }
 
   if (!exam || shuffledQuestions.length === 0) {

--- a/mobileAppFrontend/app/(student)/results/[submissionId].tsx
+++ b/mobileAppFrontend/app/(student)/results/[submissionId].tsx
@@ -1,6 +1,9 @@
 import { Ionicons } from "@expo/vector-icons";
 import { router, useLocalSearchParams } from "expo-router";
-import { Pressable, SafeAreaView, ScrollView, StyleSheet, Text, View } from "react-native";
+import { useEffect, useState } from "react";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { FullScreenLoader } from "@/components/FullScreenLoader";
 import { MathText } from "@/components/MathText";
 import { StatusCard } from "@/components/StatusCard";
 import { useAppData } from "@/data/app-data";
@@ -31,30 +34,66 @@ function getChoiceTone(answer: SubmissionAnswer, optionId: string) {
 export default function ResultDetailScreen() {
   const params = useLocalSearchParams<{ submissionId: string }>();
   const submissionId = typeof params.submissionId === "string" ? params.submissionId : "";
-  const { getSubmissionById } = useAppData();
+  const { ensureSubmissionLoaded, getSubmissionById } = useAppData();
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState("");
   const detail = getSubmissionById(submissionId);
+
+  useEffect(() => {
+    if (!submissionId || !detail || detail.answers.length > 0) {
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+    setLoadError("");
+
+    void ensureSubmissionLoaded(submissionId)
+      .catch((caughtError) => {
+        if (!cancelled) {
+          setLoadError(
+            caughtError instanceof Error ? caughtError.message : "Задлан мэдээллийг ачаалж чадсангүй.",
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [detail, ensureSubmissionLoaded, submissionId]);
+
+  if (detail && detail.answers.length === 0 && isLoading) {
+    return <FullScreenLoader label="Задлан мэдээллийг ачаалж байна..." />;
+  }
 
   if (!detail) {
     return (
-      <SafeAreaView style={styles.page}>
+      <SafeAreaView edges={["top", "left", "right"]} style={styles.page}>
         <View style={styles.content}>
           <Pressable style={styles.backButton} onPress={() => router.back()}>
             <Ionicons name="chevron-back" size={18} color={colors.textPrimary} />
             <Text style={styles.backText}>Буцах</Text>
           </Pressable>
-          <StatusCard tone="error" message="Задлан харах мэдээлэл олдсонгүй." />
+          <StatusCard tone="error" message={loadError || "Задлан харах мэдээлэл олдсонгүй."} />
         </View>
       </SafeAreaView>
     );
   }
 
   return (
-    <SafeAreaView style={styles.page}>
+    <SafeAreaView edges={["top", "left", "right"]} style={styles.page}>
       <ScrollView contentContainerStyle={styles.content}>
         <Pressable style={styles.backButton} onPress={() => router.back()}>
           <Ionicons name="chevron-back" size={18} color={colors.textPrimary} />
           <Text style={styles.backText}>Буцах</Text>
         </Pressable>
+
+        {loadError ? <StatusCard tone="warning" message={loadError} /> : null}
 
         <View style={styles.heroCard}>
           <MathText value={detail.title} style={styles.heroTitle} />

--- a/mobileAppFrontend/src/components/ConfigErrorScreen.tsx
+++ b/mobileAppFrontend/src/components/ConfigErrorScreen.tsx
@@ -1,4 +1,5 @@
-import { SafeAreaView, StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { colors, fonts, shadows } from "@/lib/theme";
 
 export function ConfigErrorScreen({
@@ -9,7 +10,7 @@ export function ConfigErrorScreen({
   message: string;
 }) {
   return (
-    <SafeAreaView style={styles.page}>
+    <SafeAreaView edges={["top", "left", "right", "bottom"]} style={styles.page}>
       <View style={styles.card}>
         <Text style={styles.title}>{title}</Text>
         <Text style={styles.message}>{message}</Text>

--- a/mobileAppFrontend/src/components/FullScreenLoader.tsx
+++ b/mobileAppFrontend/src/components/FullScreenLoader.tsx
@@ -1,9 +1,10 @@
-import { ActivityIndicator, SafeAreaView, StyleSheet, Text, View } from "react-native";
+import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { colors, fonts } from "@/lib/theme";
 
 export function FullScreenLoader({ label }: { label: string }) {
   return (
-    <SafeAreaView style={styles.page}>
+    <SafeAreaView edges={["top", "left", "right", "bottom"]} style={styles.page}>
       <View style={styles.content}>
         <ActivityIndicator size="large" color={colors.primary} />
         <Text style={styles.label}>{label}</Text>

--- a/mobileAppFrontend/src/data/app-data.tsx
+++ b/mobileAppFrontend/src/data/app-data.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { AppState } from "react-native";
 import { ConfigErrorScreen } from "@/components/ConfigErrorScreen";
 import { FullScreenLoader } from "@/components/FullScreenLoader";
@@ -12,21 +12,30 @@ import {
   saveRemoteSnapshot,
 } from "@/lib/app-storage";
 import {
-  fetchRemoteAvailableExamIds,
+  fetchRemoteAvailableExams,
   fetchRemoteExamById,
   fetchRemoteStudentProfile,
   fetchRemoteSubmissionById,
-  fetchRemoteSubmissionIds,
+  fetchRemoteSubmissions,
   getMobileRemoteConfig,
   submitRemoteStudentExam,
 } from "@/lib/mobile-graphql";
 
+type RemoteSnapshot = {
+  student: StudentProfile;
+  availableExams: Exam[];
+  submissions: Submission[];
+};
+
 type AppDataContextValue = {
+  isRemoteData: boolean;
   student: StudentProfile;
   availableExams: Exam[];
   submissions: Submission[];
   getExamById: (examId: string) => Exam | null;
   getSubmissionById: (submissionId: string) => Submission | null;
+  ensureExamLoaded: (examId: string) => Promise<Exam | null>;
+  ensureSubmissionLoaded: (submissionId: string) => Promise<Submission | null>;
   refreshData: () => Promise<void>;
   submitExam: (input: {
     examId: string;
@@ -42,6 +51,42 @@ function buildSubmissionId(examId: string) {
   return `submission-${examId}`;
 }
 
+function mergeExamCache(existing: Exam[], incoming: Exam[]) {
+  const existingById = new Map(existing.map((exam) => [exam.id, exam]));
+
+  return incoming.map((exam) => {
+    const cachedExam = existingById.get(exam.id);
+
+    if (cachedExam && cachedExam.questions.length > 0 && exam.questions.length === 0) {
+      return {
+        ...exam,
+        questions: cachedExam.questions,
+      };
+    }
+
+    return exam;
+  });
+}
+
+function mergeSubmissionCache(existing: Submission[], incoming: Submission[]) {
+  const existingById = new Map(existing.map((submission) => [submission.id, submission]));
+
+  return incoming.map((submission) => {
+    const cachedSubmission = existingById.get(submission.id);
+
+    if (cachedSubmission && cachedSubmission.answers.length > 0 && submission.answers.length === 0) {
+      return {
+        ...submission,
+        scheduledDate: cachedSubmission.scheduledDate ?? submission.scheduledDate,
+        startTime: cachedSubmission.startTime ?? submission.startTime,
+        answers: cachedSubmission.answers,
+      };
+    }
+
+    return submission;
+  });
+}
+
 export function AppDataProvider({ children }: { children: ReactNode }) {
   const remoteConfig = getMobileRemoteConfig();
   const useRemoteData = Boolean(remoteConfig);
@@ -50,6 +95,21 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
   const [remoteAvailableExams, setRemoteAvailableExams] = useState<Exam[]>([]);
   const [bootStatus, setBootStatus] = useState<"loading" | "ready" | "error">("loading");
   const [bootError, setBootError] = useState("");
+  const studentRef = useRef(studentProfile);
+  const submissionsRef = useRef<Submission[]>([...seedSubmissions]);
+  const remoteAvailableExamsRef = useRef<Exam[]>([]);
+
+  useEffect(() => {
+    studentRef.current = student;
+  }, [student]);
+
+  useEffect(() => {
+    submissionsRef.current = submissions;
+  }, [submissions]);
+
+  useEffect(() => {
+    remoteAvailableExamsRef.current = remoteAvailableExams;
+  }, [remoteAvailableExams]);
 
   const submittedExamIds = useMemo(
     () => new Set(submissions.map((submission) => submission.examId)),
@@ -62,15 +122,10 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
   );
 
   const pullRemoteSnapshot = useCallback(async () => {
-    const [nextStudent, availableExamIds, submissionIds] = await Promise.all([
+    const [nextStudent, nextAvailableExams, nextSubmissions] = await Promise.all([
       fetchRemoteStudentProfile(),
-      fetchRemoteAvailableExamIds(),
-      fetchRemoteSubmissionIds(),
-    ]);
-
-    const [nextAvailableExams, nextSubmissions] = await Promise.all([
-      Promise.all(availableExamIds.map((examId) => fetchRemoteExamById(examId))),
-      Promise.all(submissionIds.map((submissionId) => fetchRemoteSubmissionById(submissionId))),
+      fetchRemoteAvailableExams(),
+      fetchRemoteSubmissions(),
     ]);
 
     return {
@@ -80,20 +135,29 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
-  const applyRemoteSnapshot = useCallback(
-    (snapshot: { student: StudentProfile; availableExams: Exam[]; submissions: Submission[] }) => {
-      setStudent(snapshot.student);
-      setRemoteAvailableExams(snapshot.availableExams);
-      setSubmissions(snapshot.submissions);
-    },
-    [],
-  );
+  const applyRemoteSnapshot = useCallback((snapshot: RemoteSnapshot) => {
+    const mergedSnapshot: RemoteSnapshot = {
+      student: snapshot.student,
+      availableExams: mergeExamCache(remoteAvailableExamsRef.current, snapshot.availableExams),
+      submissions: mergeSubmissionCache(submissionsRef.current, snapshot.submissions),
+    };
+
+    studentRef.current = mergedSnapshot.student;
+    remoteAvailableExamsRef.current = mergedSnapshot.availableExams;
+    submissionsRef.current = mergedSnapshot.submissions;
+
+    setStudent(mergedSnapshot.student);
+    setRemoteAvailableExams(mergedSnapshot.availableExams);
+    setSubmissions(mergedSnapshot.submissions);
+
+    return mergedSnapshot;
+  }, []);
 
   const refreshRemoteSnapshot = useCallback(async () => {
     const snapshot = await pullRemoteSnapshot();
-    applyRemoteSnapshot(snapshot);
-    await saveRemoteSnapshot(snapshot);
-    return snapshot;
+    const mergedSnapshot = applyRemoteSnapshot(snapshot);
+    await saveRemoteSnapshot(mergedSnapshot);
+    return mergedSnapshot;
   }, [applyRemoteSnapshot, pullRemoteSnapshot]);
 
   useEffect(() => {
@@ -136,9 +200,9 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
         const snapshot = await pullRemoteSnapshot();
 
         if (!cancelled) {
-          applyRemoteSnapshot(snapshot);
+          const mergedSnapshot = applyRemoteSnapshot(snapshot);
           setBootStatus("ready");
-          void saveRemoteSnapshot(snapshot);
+          void saveRemoteSnapshot(mergedSnapshot);
         }
       } catch (caughtError) {
         if (!cancelled && !cachedSnapshot) {
@@ -202,6 +266,61 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
   const getSubmissionById = useCallback(
     (submissionId: string) => submissions.find((submission) => submission.id === submissionId) ?? null,
     [submissions],
+  );
+
+  const ensureExamLoaded = useCallback(
+    async (examId: string) => {
+      const source = useRemoteData ? remoteAvailableExamsRef.current : examCatalog;
+      const existingExam = source.find((exam) => exam.id === examId) ?? null;
+
+      if (!existingExam || !useRemoteData || existingExam.questions.length > 0 || existingExam.questionCount === 0) {
+        return existingExam;
+      }
+
+      const detailedExam = await fetchRemoteExamById(examId);
+      const nextAvailableExams = remoteAvailableExamsRef.current.map((exam) =>
+        exam.id === examId ? detailedExam : exam,
+      );
+
+      remoteAvailableExamsRef.current = nextAvailableExams;
+      setRemoteAvailableExams(nextAvailableExams);
+
+      await saveRemoteSnapshot({
+        student: studentRef.current,
+        availableExams: nextAvailableExams,
+        submissions: submissionsRef.current,
+      });
+
+      return detailedExam;
+    },
+    [useRemoteData],
+  );
+
+  const ensureSubmissionLoaded = useCallback(
+    async (submissionId: string) => {
+      const existingSubmission = submissionsRef.current.find((submission) => submission.id === submissionId) ?? null;
+
+      if (!existingSubmission || !useRemoteData || existingSubmission.answers.length > 0) {
+        return existingSubmission;
+      }
+
+      const detailedSubmission = await fetchRemoteSubmissionById(submissionId);
+      const nextSubmissions = submissionsRef.current.map((submission) =>
+        submission.id === submissionId ? detailedSubmission : submission,
+      );
+
+      submissionsRef.current = nextSubmissions;
+      setSubmissions(nextSubmissions);
+
+      await saveRemoteSnapshot({
+        student: studentRef.current,
+        availableExams: remoteAvailableExamsRef.current,
+        submissions: nextSubmissions,
+      });
+
+      return detailedSubmission;
+    },
+    [useRemoteData],
   );
 
   const refreshData = useCallback(async () => {
@@ -301,16 +420,31 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
 
   const value = useMemo<AppDataContextValue>(
     () => ({
+      isRemoteData: useRemoteData,
       student,
       availableExams,
       submissions,
       getExamById,
       getSubmissionById,
+      ensureExamLoaded,
+      ensureSubmissionLoaded,
       refreshData,
       submitExam,
       resetData,
     }),
-    [availableExams, getExamById, getSubmissionById, refreshData, resetData, student, submitExam, submissions],
+    [
+      availableExams,
+      ensureExamLoaded,
+      ensureSubmissionLoaded,
+      getExamById,
+      getSubmissionById,
+      refreshData,
+      resetData,
+      student,
+      submitExam,
+      submissions,
+      useRemoteData,
+    ],
   );
 
   if (bootStatus === "loading") {

--- a/mobileAppFrontend/src/data/student-data.ts
+++ b/mobileAppFrontend/src/data/student-data.ts
@@ -1,6 +1,7 @@
 import type { Exam, StudentProfile, Submission } from "@/data/types";
 
 export const studentProfile: StudentProfile = {
+  id: "student-demo-001",
   fullName: "Б. Тэмүүлэн",
   firstName: "Тэмүүлэн",
   lastName: "Б",
@@ -20,6 +21,7 @@ export const examCatalog: Exam[] = [
     duration: 20,
     scheduledDate: "2026-03-31",
     startTime: "09:00",
+    questionCount: 3,
     questions: [
       {
         id: "math-q1",
@@ -68,6 +70,7 @@ export const examCatalog: Exam[] = [
     duration: 15,
     scheduledDate: "2026-03-31",
     startTime: "14:30",
+    questionCount: 3,
     questions: [
       {
         id: "eng-q1",

--- a/mobileAppFrontend/src/data/types.ts
+++ b/mobileAppFrontend/src/data/types.ts
@@ -22,6 +22,7 @@ export type Exam = {
   duration: number;
   scheduledDate: string;
   startTime: string;
+  questionCount: number;
   questions: Question[];
 };
 
@@ -58,6 +59,7 @@ export type Submission = {
 };
 
 export type StudentProfile = {
+  id: string;
   fullName: string;
   firstName: string;
   lastName: string;

--- a/mobileAppFrontend/src/lib/app-storage.ts
+++ b/mobileAppFrontend/src/lib/app-storage.ts
@@ -79,6 +79,7 @@ function isStudentProfile(value: unknown): value is StudentProfile {
   const student = value as StudentProfile;
 
   return (
+    typeof student.id === "string" &&
     typeof student.fullName === "string" &&
     typeof student.firstName === "string" &&
     typeof student.lastName === "string" &&

--- a/mobileAppFrontend/src/lib/mobile-graphql.ts
+++ b/mobileAppFrontend/src/lib/mobile-graphql.ts
@@ -18,6 +18,7 @@ type GraphqlResponse<TData> = {
 
 type RemoteStudentProfile = {
   studentById: {
+    id: string;
     firstName: string;
     lastName: string;
     email: string;
@@ -124,6 +125,7 @@ type SubmitStudentExamResponse = {
 const GET_CURRENT_STUDENT = `
   query GetCurrentStudentProfile {
     studentById {
+      id
       firstName
       lastName
       email
@@ -301,6 +303,7 @@ async function fetchGraphql<TData>(query: string, variables?: Record<string, unk
 
 function mapStudentProfile(payload: RemoteStudentProfile["studentById"]): StudentProfile {
   return {
+    id: payload.id,
     fullName: [payload.lastName, payload.firstName].filter(Boolean).join(" "),
     firstName: payload.firstName,
     lastName: payload.lastName,
@@ -308,6 +311,23 @@ function mapStudentProfile(payload: RemoteStudentProfile["studentById"]): Studen
     role: "student",
     phone: payload.phone,
     inviteCode: payload.inviteCode,
+  };
+}
+
+function mapAvailableExamSummary(
+  payload: RemoteAvailableExams["availableExamsForStudent"][number],
+): Exam {
+  return {
+    id: payload.id,
+    title: payload.title,
+    subject: payload.subject,
+    description: payload.description ?? "",
+    grade: payload.grade,
+    duration: payload.duration,
+    scheduledDate: payload.scheduledDate ?? "",
+    startTime: payload.startTime ?? "",
+    questionCount: payload.questionCount,
+    questions: [],
   };
 }
 
@@ -321,6 +341,7 @@ function mapExam(payload: RemoteExamDetail["studentExamDetail"]): Exam {
     duration: payload.duration,
     scheduledDate: payload.scheduledDate ?? "",
     startTime: payload.startTime ?? "",
+    questionCount: payload.questionCount,
     questions: payload.questions.map((question) => ({
       id: question.id,
       type: "mcq",
@@ -333,6 +354,26 @@ function mapExam(payload: RemoteExamDetail["studentExamDetail"]): Exam {
         isCorrect: false,
       })),
     })),
+  };
+}
+
+function mapSubmissionSummary(
+  payload: RemoteSubmissionSummaries["myExamSubmissions"][number],
+): Submission {
+  return {
+    id: payload.id,
+    examId: payload.examId,
+    title: payload.title,
+    subject: payload.subject,
+    grade: payload.grade,
+    duration: payload.duration,
+    questionCount: payload.questionCount,
+    correctAnswers: payload.correctAnswers,
+    scorePercent: payload.scorePercent,
+    submittedAt: payload.submittedAt,
+    scheduledDate: null,
+    startTime: null,
+    answers: [],
   };
 }
 
@@ -373,9 +414,9 @@ export async function fetchRemoteStudentProfile() {
   return mapStudentProfile(payload.studentById);
 }
 
-export async function fetchRemoteAvailableExamIds() {
+export async function fetchRemoteAvailableExams() {
   const payload = await fetchGraphql<RemoteAvailableExams>(GET_AVAILABLE_EXAMS);
-  return payload.availableExamsForStudent.map((exam) => exam.id);
+  return payload.availableExamsForStudent.map(mapAvailableExamSummary);
 }
 
 export async function fetchRemoteExamById(examId: string) {
@@ -383,9 +424,9 @@ export async function fetchRemoteExamById(examId: string) {
   return mapExam(payload.studentExamDetail);
 }
 
-export async function fetchRemoteSubmissionIds() {
+export async function fetchRemoteSubmissions() {
   const payload = await fetchGraphql<RemoteSubmissionSummaries>(GET_MY_EXAM_SUBMISSIONS);
-  return payload.myExamSubmissions.map((submission) => submission.id);
+  return payload.myExamSubmissions.map(mapSubmissionSummary);
 }
 
 export async function fetchRemoteSubmissionById(submissionId: string) {

--- a/mobileAppFrontend/src/security/session-integrity.ts
+++ b/mobileAppFrontend/src/security/session-integrity.ts
@@ -1,4 +1,5 @@
 import * as SecureStore from "expo-secure-store";
+import { getMobileRemoteConfig } from "@/lib/mobile-graphql";
 import { SessionBackendStatus } from "@/security/types";
 
 const SESSION_QUEUE_KEY = "pinequest_session_integrity_queue";
@@ -19,6 +20,11 @@ type SessionAction = {
 
 type SessionBackendResponse = {
   status?: SessionBackendStatus;
+};
+
+type SessionBackendConfig = {
+  endpoint: string;
+  headers: Record<string, string>;
 };
 
 type CreateSessionIntegrityOptions = {
@@ -71,24 +77,47 @@ async function enqueueAction(action: SessionAction) {
   await writeQueue([...current, action]);
 }
 
-function getSessionIntegrityEndpoint() {
-  return process.env.EXPO_PUBLIC_SESSION_INTEGRITY_URL?.trim() ?? "";
+function getSessionBackendConfig(): SessionBackendConfig | null {
+  const configuredEndpoint = process.env.EXPO_PUBLIC_SESSION_INTEGRITY_URL?.trim() ?? "";
+
+  if (configuredEndpoint) {
+    return {
+      endpoint: configuredEndpoint,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+  }
+
+  const remoteConfig = getMobileRemoteConfig();
+
+  if (!remoteConfig) {
+    return null;
+  }
+
+  return {
+    endpoint: remoteConfig.graphqlUrl.replace(/\/graphql\/?$/i, "/session-integrity"),
+    headers: {
+      "Content-Type": "application/json",
+      "x-mobile-demo-key": remoteConfig.accessKey,
+      "x-mobile-student-email": remoteConfig.studentEmail,
+      "x-mobile-student-invite-code": remoteConfig.studentInviteCode,
+    },
+  };
 }
 
 async function postSessionAction(action: SessionAction): Promise<SessionBackendStatus> {
-  const endpoint = getSessionIntegrityEndpoint();
+  const backendConfig = getSessionBackendConfig();
 
-  if (!endpoint) {
+  if (!backendConfig) {
     await enqueueAction(action);
     return "queued_offline";
   }
 
   try {
-    const response = await fetch(endpoint, {
+    const response = await fetch(backendConfig.endpoint, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
+      headers: backendConfig.headers,
       body: JSON.stringify(action),
     });
 
@@ -106,9 +135,9 @@ async function postSessionAction(action: SessionAction): Promise<SessionBackendS
 }
 
 async function flushQueuedActions() {
-  const endpoint = getSessionIntegrityEndpoint();
+  const backendConfig = getSessionBackendConfig();
 
-  if (!endpoint) {
+  if (!backendConfig) {
     return "skipped" as SessionBackendStatus;
   }
 
@@ -122,11 +151,9 @@ async function flushQueuedActions() {
 
   for (const action of queue) {
     try {
-      const response = await fetch(endpoint, {
+      const response = await fetch(backendConfig.endpoint, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
+        headers: backendConfig.headers,
         body: JSON.stringify(action),
       });
 


### PR DESCRIPTION
## Summary
Student mobile app-ийн session integrity-г authoritative backend-р хэрэгжүүлэв.

## Implemented
- D1 дээр `student_exam_sessions` table нэмсэн
- `/session-integrity` backend route нэмсэн
- Route нь `start`, `heartbeat`, `stop` action хүлээж авдаг болсон
- Clerk auth болон mobile demo auth header хоёулантай нь ажилладаг unified auth resolution нэмсэн
- Stale/offline queued session action нь шинэ active session-ийг overwrite хийхгүй хамгаалалт нэмсэн
- Mobile app session identity-г `student.email`-ээс `student.id` болгож зассан
- Mobile session client нь GraphQL URL-ээс `/session-integrity` endpoint-ээ автоматаар derive хийдэг болсон
- Mobile session request-үүд GraphQL-тэй ижил demo auth header-уудыг reuse хийдэг болсон

## Backend files
- `cold-king-fc65/src/index.ts`
- `cold-king-fc65/src/server.ts`
- `cold-king-fc65/src/db/client.ts`
- `cold-king-fc65/src/db/schemas/student-exam-session.schema.ts`
- `cold-king-fc65/migrations/0004_student_exam_sessions.sql`

## Mobile files
- `mobileAppFrontend/src/data/types.ts`
- `mobileAppFrontend/src/data/student-data.ts`
- `mobileAppFrontend/src/lib/app-storage.ts`
- `mobileAppFrontend/src/lib/mobile-graphql.ts`
- `mobileAppFrontend/src/security/session-integrity.ts`
- `mobileAppFrontend/app/(student)/exam/[examId]/take.tsx`

## Validation
- `cd cold-king-fc65 && npx tsc --noEmit` passed
- `cd mobileAppFrontend && npx tsc --noEmit` passed

## Manual follow-up
- Run D1 migration:
  - `cd cold-king-fc65`
  - `npx wrangler d1 migrations apply shalgalt_db --remote`
- Restart backend and mobile app
