### PR TITLE
redesign mobile student exam detail screen to match new card-based la…

### DIFF
--- a/mobileAppFrontend/app/(student)/(tabs)/index.tsx
+++ b/mobileAppFrontend/app/(student)/(tabs)/index.tsx
@@ -5,7 +5,12 @@ import { Image, Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } 
 import { SafeAreaView } from "react-native-safe-area-context";
 import { EmptyState } from "@/components/EmptyState";
 import { useAppData } from "@/data/app-data";
-import { formatScheduledDate, formatScheduledTime, getStudentExamPresentation } from "@/lib/student-exam";
+import {
+  buildStudentExamSubjectOrder,
+  formatScheduledDate,
+  formatScheduledTime,
+  getStudentExamPresentation,
+} from "@/lib/student-exam";
 import { colors, fonts, shadows } from "@/lib/theme";
 
 const learningMsLogo = require("../../../assets/learning-ms-logo.png");
@@ -17,6 +22,7 @@ export default function StudentHomeScreen() {
 
   const scheduledExams = useMemo(() => [] as typeof availableExams, []);
   const visibleExams = selectedTab === "active" ? availableExams : scheduledExams;
+  const subjectOrder = useMemo(() => buildStudentExamSubjectOrder(visibleExams), [visibleExams]);
 
   const handleRefresh = async () => {
     setIsRefreshing(true);
@@ -81,6 +87,7 @@ export default function StudentHomeScreen() {
               <HomeExamCard
                 key={exam.id}
                 exam={exam}
+                subjectOrder={subjectOrder}
                 onPress={() => {
                   if (selectedTab === "active") {
                     router.push(`/(student)/exam/${exam.id}`);
@@ -209,18 +216,18 @@ const styles = StyleSheet.create({
   },
   cardSubject: {
     fontFamily: fonts.display.semibold,
-    fontSize: 22,
+    fontSize: 20,
     color: colors.textPrimary,
   },
   cardTopic: {
     fontFamily: fonts.sans.regular,
-    fontSize: 20,
+    fontSize: 18,
     color: colors.textMuted,
   },
   cardGrade: {
     marginTop: 14,
     fontFamily: fonts.sans.medium,
-    fontSize: 14,
+    fontSize: 16,
     color: colors.textPrimary,
   },
   cardChipRow: {
@@ -273,6 +280,7 @@ const styles = StyleSheet.create({
 
 function HomeExamCard({
   exam,
+  subjectOrder,
   onPress,
 }: {
   exam: {
@@ -285,13 +293,21 @@ function HomeExamCard({
     scheduledDate: string;
     startTime: string;
   };
+  subjectOrder: string[];
   onPress: () => void;
 }) {
-  const presentation = getStudentExamPresentation(exam.subject);
+  const presentation = getStudentExamPresentation(exam.subject, subjectOrder);
 
   return (
     <Pressable
-      style={({ pressed }) => [styles.card, { backgroundColor: presentation.background }, pressed ? styles.cardPressed : null]}
+      style={({ pressed }) => [
+        styles.card,
+        {
+          backgroundColor: presentation.background,
+          borderColor: presentation.borderColor,
+        },
+        pressed ? styles.cardPressed : null,
+      ]}
       onPress={onPress}
     >
       <View style={styles.cardTop}>

--- a/mobileAppFrontend/app/(student)/(tabs)/results.tsx
+++ b/mobileAppFrontend/app/(student)/(tabs)/results.tsx
@@ -4,11 +4,12 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { EmptyState } from "@/components/EmptyState";
 import { StudentExamCard } from "@/components/StudentExamCard";
 import { useAppData } from "@/data/app-data";
+import { buildStudentExamSubjectOrder, formatStudentExamTimestamp } from "@/lib/student-exam";
 import { colors, fonts, shadows } from "@/lib/theme";
-import { formatStudentExamTimestamp } from "@/lib/student-exam";
 
 export default function ResultsScreen() {
   const { submissions } = useAppData();
+  const subjectOrder = buildStudentExamSubjectOrder(submissions);
 
   return (
     <SafeAreaView edges={["top", "left", "right"]} style={styles.page}>
@@ -36,6 +37,7 @@ export default function ResultsScreen() {
                 scheduledDate={formatStudentExamTimestamp(submission.submittedAt)}
                 startTime={`${submission.correctAnswers} зөв`}
                 footerLabel={`${submission.scorePercent}%`}
+                subjectOrder={subjectOrder}
                 onPress={() => {
                   router.push(`/(student)/results/${submission.id}`);
                 }}

--- a/mobileAppFrontend/app/(student)/exam/[examId].tsx
+++ b/mobileAppFrontend/app/(student)/exam/[examId].tsx
@@ -1,10 +1,16 @@
-import { Ionicons } from "@expo/vector-icons";
+import { Ionicons, MaterialCommunityIcons } from "@expo/vector-icons";
 import { router, useLocalSearchParams } from "expo-router";
 import { useEffect, useMemo, useState } from "react";
-import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import {
+  ActivityIndicator,
+  Image,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { MathText } from "@/components/MathText";
-import { PrimaryButton } from "@/components/PrimaryButton";
 import { StatusCard } from "@/components/StatusCard";
 import { useAppData } from "@/data/app-data";
 import {
@@ -14,27 +20,34 @@ import {
   getExamReminderDate,
   scheduleExamReminder,
 } from "@/lib/notifications";
-import { colors, fonts, shadows } from "@/lib/theme";
 import {
-  formatScheduledDate,
+  buildStudentExamSubjectOrder,
   formatScheduledTime,
   getExamEndTime,
   getStudentExamPresentation,
 } from "@/lib/student-exam";
+import { colors, fonts, shadows } from "@/lib/theme";
+
+const learningMsLogo = require("../../../assets/learning-ms-logo.png");
 
 export default function ExamDetailScreen() {
   const params = useLocalSearchParams<{ examId: string }>();
   const examId = typeof params.examId === "string" ? params.examId : "";
-  const { ensureExamLoaded, getExamById } = useAppData();
+  const { availableExams, ensureExamLoaded, getExamById } = useAppData();
   const [reminderMessage, setReminderMessage] = useState("");
   const [hasReminder, setHasReminder] = useState(false);
   const [isReminderLoading, setIsReminderLoading] = useState(false);
   const [isExamLoading, setIsExamLoading] = useState(false);
   const [examLoadError, setExamLoadError] = useState("");
+
   const exam = getExamById(examId);
+  const subjectOrder = useMemo(
+    () => buildStudentExamSubjectOrder(exam ? [...availableExams, exam] : availableExams),
+    [availableExams, exam],
+  );
   const presentation = useMemo(
-    () => (exam ? getStudentExamPresentation(exam.subject) : null),
-    [exam],
+    () => (exam ? getStudentExamPresentation(exam.subject, subjectOrder) : null),
+    [exam, subjectOrder],
   );
   const reminderDate = useMemo(
     () => getExamReminderDate(exam?.scheduledDate, exam?.startTime),
@@ -77,7 +90,9 @@ export default function ExamDetailScreen() {
       .catch((caughtError) => {
         if (!cancelled) {
           setExamLoadError(
-            caughtError instanceof Error ? caughtError.message : "Шалгалтын дэлгэрэнгүйг ачаалж чадсангүй.",
+            caughtError instanceof Error
+              ? caughtError.message
+              : "Шалгалтын дэлгэрэнгүйг ачаалж чадсангүй.",
           );
         }
       })
@@ -112,6 +127,7 @@ export default function ExamDetailScreen() {
           scheduledDate: exam.scheduledDate,
           startTime: exam.startTime,
         });
+
         setHasReminder(true);
         setReminderMessage(`${formatReminderDate(scheduled.reminderDate)}-д сануулга тавигдлаа.`);
       }
@@ -157,10 +173,6 @@ export default function ExamDetailScreen() {
     return (
       <SafeAreaView edges={["top", "left", "right"]} style={styles.page}>
         <View style={styles.content}>
-          <Pressable style={styles.backButton} onPress={() => router.back()}>
-            <Ionicons name="chevron-back" size={18} color={colors.textPrimary} />
-            <Text style={styles.backText}>Буцах</Text>
-          </Pressable>
           <StatusCard tone="error" message="Шалгалтын мэдээлэл олдсонгүй." />
         </View>
       </SafeAreaView>
@@ -169,79 +181,124 @@ export default function ExamDetailScreen() {
 
   return (
     <SafeAreaView edges={["top", "left", "right"]} style={styles.page}>
-      <ScrollView contentContainerStyle={styles.content}>
-        <Pressable style={styles.backButton} onPress={() => router.back()}>
-          <Ionicons name="chevron-back" size={18} color={colors.textPrimary} />
-          <Text style={styles.backText}>Буцах</Text>
-        </Pressable>
+      <View style={styles.header}>
+        <View style={styles.brandMarkWrap}>
+          <Image source={learningMsLogo} style={styles.brandImage} resizeMode="contain" />
+        </View>
+        <View>
+          <Text style={styles.brandTop}>Learning</Text>
+          <Text style={styles.brandBottom}>MS</Text>
+        </View>
+      </View>
 
+      <ScrollView contentContainerStyle={styles.content}>
         {reminderMessage ? (
           <StatusCard
             tone={hasReminder ? "success" : reminderDate ? "info" : "warning"}
             message={reminderMessage}
           />
         ) : null}
+
         {examLoadError ? <StatusCard tone="error" message={examLoadError} /> : null}
 
-        <View style={styles.card}>
-          <Text style={styles.subjectBadge}>{presentation?.subjectLabel}</Text>
-          <MathText value={exam.title} style={styles.subjectLabel} />
-          <MathText value={exam.description} style={styles.description} />
+        <View
+          style={[
+            styles.card,
+            {
+              backgroundColor: presentation?.background ?? "#F4F1FF",
+              borderColor: presentation?.borderColor ?? "#CFC6FF",
+            },
+          ]}
+        >
+          <Text style={styles.titleText} numberOfLines={1} ellipsizeMode="tail">
+            <Text style={styles.subjectText}>{presentation?.subjectLabel}</Text>
+            <Text style={styles.topicText}> /{exam.title}/</Text>
+          </Text>
 
           <View style={styles.metaRow}>
-            <View style={styles.metaChip}>
-              <Ionicons name="time-outline" size={14} color={colors.textSecondary} />
+            <View style={[styles.metaChip, styles.metaChipDuration]}>
+              <Ionicons name="time-outline" size={17} color={colors.textPrimary} />
               <Text style={styles.metaChipText}>{exam.duration} мин</Text>
             </View>
-            <View style={styles.metaChip}>
-              <Ionicons name="document-text-outline" size={14} color={colors.textSecondary} />
-              <Text style={styles.metaChipText}>{exam.questionCount} даалгавар</Text>
+
+            <View style={[styles.metaChip, styles.metaChipQuestions]}>
+              <MaterialCommunityIcons
+                name="pencil-outline"
+                size={17}
+                color={colors.textPrimary}
+              />
+              <Text style={styles.metaChipText}>{exam.questionCount} дасгал</Text>
             </View>
           </View>
 
-          <View style={styles.scheduleBox}>
-            <View style={styles.scheduleRow}>
-              <Text style={styles.scheduleLabel}>Өдөр</Text>
-              <Text style={styles.scheduleValue}>{formatScheduledDate(exam.scheduledDate)}</Text>
+          <View style={styles.scheduleRow}>
+            <View style={styles.scheduleItem}>
+              <View style={styles.scheduleAccent} />
+              <View>
+                <Text style={styles.scheduleLabel}>ЭХЛЭХ ЦАГ</Text>
+                <Text style={styles.scheduleValue}>{formatScheduledTime(exam.startTime)}</Text>
+              </View>
             </View>
-            <View style={styles.scheduleRow}>
-              <Text style={styles.scheduleLabel}>Эхлэх</Text>
-              <Text style={styles.scheduleValue}>{formatScheduledTime(exam.startTime)}</Text>
-            </View>
-            <View style={styles.scheduleRow}>
-              <Text style={styles.scheduleLabel}>Дуусах</Text>
-              <Text style={styles.scheduleValue}>
-                {getExamEndTime(exam.startTime, exam.duration)}
-              </Text>
+
+            <View style={styles.scheduleItem}>
+              <View style={styles.scheduleAccent} />
+              <View>
+                <Text style={styles.scheduleLabel}>ДУУСАХ ЦАГ</Text>
+                <Text style={styles.scheduleValue}>
+                  {getExamEndTime(exam.startTime, exam.duration)}
+                </Text>
+              </View>
             </View>
           </View>
 
           <View style={styles.noticeBox}>
+            <Ionicons name="information-circle-outline" size={22} color={colors.textPrimary} />
             <Text style={styles.noticeText}>
-              Шалгалтын үеэр дэлгэц бичлэгийн хамгаалалт, дэлгэцийн зураг авах сэрэмжлүүлэг,
-              аппаас гарах анхааруулга зэрэг хамгаалалт ажиллана.
+              Шалгалтын үед хяналт болон хамгаалалтын функцууд идэвхтэй ажиллана.
             </Text>
           </View>
 
-          <PrimaryButton
-            label={
-              isReminderLoading
-                ? "Тохируулж байна..."
-                : hasReminder
-                  ? "Сануулга цуцлах"
-                  : "15 минутын өмнө сануулах"
-            }
-            onPress={() => void handleReminderPress()}
-            disabled={isReminderLoading || !reminderDate || reminderDate.getTime() <= Date.now()}
-            loading={isReminderLoading}
-            variant="secondary"
-          />
-          <PrimaryButton
-            label="Эхлэх"
-            onPress={() => void handleStartPress()}
-            disabled={isExamLoading || exam.questionCount === 0}
-            loading={isExamLoading}
-          />
+          {reminderDate ? (
+            <Pressable
+              style={styles.reminderLink}
+              onPress={() => void handleReminderPress()}
+              disabled={isReminderLoading || reminderDate.getTime() <= Date.now()}
+            >
+              <Text style={styles.reminderLinkText}>
+                {isReminderLoading
+                  ? "Тохируулж байна..."
+                  : hasReminder
+                    ? "Сануулга цуцлах"
+                    : "15 минутын өмнө сануулах"}
+              </Text>
+            </Pressable>
+          ) : null}
+
+          <View style={styles.actionRow}>
+            <Pressable style={styles.backAction} onPress={() => router.back()}>
+              <Text style={styles.backActionText}>Буцах</Text>
+            </Pressable>
+
+            <View
+              style={[
+                styles.startActionShell,
+                isExamLoading || exam.questionCount === 0 ? styles.startActionDisabled : null,
+              ]}
+            >
+              <Pressable
+                style={styles.startAction}
+                onPress={() => void handleStartPress()}
+                disabled={isExamLoading || exam.questionCount === 0}
+              >
+                <View pointerEvents="none" style={styles.startActionInset} />
+                {isExamLoading ? (
+                  <ActivityIndicator color="#FFFFFF" />
+                ) : (
+                  <Text style={styles.startActionText}>Эхлэх</Text>
+                )}
+              </Pressable>
+            </View>
+          </View>
         </View>
       </ScrollView>
     </SafeAreaView>
@@ -251,100 +308,212 @@ export default function ExamDetailScreen() {
 const styles = StyleSheet.create({
   page: {
     flex: 1,
-    backgroundColor: colors.pageBackground,
+    backgroundColor: "#FFFFFF",
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    paddingHorizontal: 24,
+    paddingBottom: 18,
+    paddingTop: 10,
+    backgroundColor: "#FFFFFF",
+  },
+  brandMarkWrap: {
+    height: 32,
+    width: 43,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  brandImage: {
+    width: 43,
+    height: 32,
+  },
+  brandTop: {
+    fontFamily: fonts.display.medium,
+    fontSize: 19,
+    color: colors.textPrimary,
+  },
+  brandBottom: {
+    marginTop: -2,
+    fontFamily: fonts.display.medium,
+    fontSize: 19,
+    color: colors.textPrimary,
   },
   content: {
     paddingHorizontal: 20,
-    paddingTop: 12,
-    paddingBottom: 40,
-  },
-  backButton: {
-    marginBottom: 16,
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 6,
-    alignSelf: "flex-start",
-  },
-  backText: {
-    fontFamily: fonts.sans.semibold,
-    fontSize: 15,
-    color: colors.textPrimary,
+    paddingTop: 120,
+    paddingBottom: 48,
   },
   card: {
-    borderRadius: 30,
-    backgroundColor: colors.surface,
-    padding: 22,
+    alignSelf: "center",
+    width: 350,
+    height: 407,
+    borderRadius: 34,
+    borderWidth: 1,
+    borderColor: "#CEC8FF",
+    paddingHorizontal: 22,
+    paddingTop: 28,
+    paddingBottom: 22,
     ...shadows.card,
   },
-  subjectLabel: {
-    marginTop: 6,
+  titleText: {
     fontFamily: fonts.display.semibold,
-    fontSize: 25,
-    lineHeight: 34,
+    fontSize: 20,
     color: colors.textPrimary,
   },
-  subjectBadge: {
-    fontFamily: fonts.sans.medium,
-    fontSize: 13,
-    color: colors.primary,
+  subjectText: {
+    fontFamily: fonts.display.medium,
+    fontSize: 20,
+    color: colors.textPrimary,
   },
-  description: {
-    marginTop: 12,
+  topicText: {
     fontFamily: fonts.sans.regular,
-    fontSize: 14,
-    lineHeight: 24,
+    fontSize: 18,
     color: colors.textMuted,
   },
   metaRow: {
-    marginTop: 18,
+    marginTop: 24,
     flexDirection: "row",
-    flexWrap: "wrap",
-    gap: 10,
+    gap: 12,
   },
   metaChip: {
+    height: 28,
     flexDirection: "row",
     alignItems: "center",
-    gap: 7,
+    justifyContent: "center",
+    gap: 8,
     borderRadius: 999,
-    backgroundColor: colors.surfaceTint,
-    paddingHorizontal: 14,
-    paddingVertical: 9,
+    backgroundColor: "#FFFFFF",
+  },
+  metaChipDuration: {
+    width: 85,
+  },
+  metaChipQuestions: {
+    width: 101,
   },
   metaChipText: {
     fontFamily: fonts.sans.medium,
-    fontSize: 13,
-    color: colors.textSecondary,
-  },
-  scheduleBox: {
-    marginTop: 20,
-    gap: 12,
+    fontSize: 12,
+    color: colors.textPrimary,
   },
   scheduleRow: {
+    marginTop: 34,
+    flexDirection: "row",
+    gap: 18,
+  },
+  scheduleItem: {
+    flex: 1,
+    height: 45,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  scheduleAccent: {
+    width: 3,
+    height: 45,
+    borderRadius: 999,
+    backgroundColor: "#D4CEFE",
+  },
+  scheduleLabel: {
+    fontFamily: fonts.sans.medium,
+    fontSize: 14,
+    color: "#9D9AA7",
+  },
+  scheduleValue: {
+    marginTop: 2,
+    fontFamily: fonts.sans.semibold,
+    fontSize: 18,
+    color: colors.textPrimary,
+  },
+  noticeBox: {
+    marginTop: 26,
+    alignSelf: "center",
+    width: 302,
+    height: 96,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: "#D6D1F7",
+    backgroundColor: "#F4F1FF",
+    paddingHorizontal: 10,
+    paddingVertical: 10,
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 10,
+  },
+  noticeText: {
+    flex: 1,
+    fontFamily: fonts.sans.medium,
+    fontSize: 16,
+    lineHeight: 22,
+    color: colors.textPrimary,
+  },
+  reminderLink: {
+    marginTop: 8,
+    alignSelf: "flex-start",
+  },
+  reminderLinkText: {
+    fontFamily: fonts.sans.medium,
+    fontSize: 13,
+    color: colors.primaryDark,
+  },
+  actionRow: {
+    marginTop: 16,
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
   },
-  scheduleLabel: {
-    fontFamily: fonts.sans.medium,
-    fontSize: 15,
+  backAction: {
+    width: 112,
+    height: 44,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  backActionText: {
+    fontFamily: fonts.display.semibold,
+    fontSize: 16,
     color: colors.textPrimary,
   },
-  scheduleValue: {
-    fontFamily: fonts.sans.regular,
-    fontSize: 15,
-    color: colors.textSecondary,
-  },
-  noticeBox: {
-    marginTop: 22,
+  startActionShell: {
+    width: 142,
+    height: 44,
     borderRadius: 18,
-    backgroundColor: colors.surfaceTint,
-    paddingHorizontal: 14,
-    paddingVertical: 14,
+    shadowColor: "#9E81F0",
+    shadowOpacity: 0.22,
+    shadowRadius: 8,
+    shadowOffset: {
+      width: 0,
+      height: 8,
+    },
+    elevation: 6,
   },
-  noticeText: {
-    fontFamily: fonts.sans.regular,
-    fontSize: 13,
-    lineHeight: 21,
-    color: colors.textSecondary,
+  startAction: {
+    flex: 1,
+    height: 44,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 18,
+    backgroundColor: "#9E81F0",
+    overflow: "hidden",
+  },
+  startActionInset: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: 5,
+    backgroundColor: "rgba(103, 79, 184, 0.38)",
+    borderBottomLeftRadius: 18,
+    borderBottomRightRadius: 18,
+  },
+  startActionDisabled: {
+    opacity: 0.6,
+  },
+  startActionText: {
+    fontFamily: fonts.display.semibold,
+    fontSize: 16,
+    color: "#FFFFFF",
   },
 });

--- a/mobileAppFrontend/src/components/StudentExamCard.tsx
+++ b/mobileAppFrontend/src/components/StudentExamCard.tsx
@@ -13,6 +13,7 @@ export function StudentExamCard({
   scheduledDate,
   startTime,
   footerLabel = "Эхлэх",
+  subjectOrder,
   onPress,
 }: {
   subject: string;
@@ -23,15 +24,19 @@ export function StudentExamCard({
   scheduledDate?: string | null;
   startTime?: string | null;
   footerLabel?: string;
+  subjectOrder?: string[];
   onPress: () => void;
 }) {
-  const presentation = getStudentExamPresentation(subject);
+  const presentation = getStudentExamPresentation(subject, subjectOrder);
 
   return (
     <Pressable
       style={({ pressed }) => [
         styles.card,
-        { backgroundColor: presentation.background },
+        {
+          backgroundColor: presentation.background,
+          borderColor: presentation.borderColor,
+        },
         pressed ? styles.pressed : null,
       ]}
       onPress={onPress}

--- a/mobileAppFrontend/src/lib/student-exam.ts
+++ b/mobileAppFrontend/src/lib/student-exam.ts
@@ -3,20 +3,89 @@ import type { MaterialCommunityIcons } from "@expo/vector-icons";
 
 type IconName = ComponentProps<typeof MaterialCommunityIcons>["name"];
 
-export function getStudentExamPresentation(subject: string): {
+const orderedSubjectPalette = [
+  {
+    background: "#E8E4F8",
+    iconBackground: "#D4CEFE",
+    borderColor: "#CFC6FF",
+  },
+  {
+    background: "#DFF0F8",
+    iconBackground: "#C8E4F4",
+    borderColor: "#B9DDEE",
+  },
+  {
+    background: "#F8E2EF",
+    iconBackground: "#F1CBE2",
+    borderColor: "#E8BCD8",
+  },
+  {
+    background: "#E3F5E8",
+    iconBackground: "#C9EBD3",
+    borderColor: "#BEE1C8",
+  },
+] as const;
+
+function normalizeSubject(subject: string) {
+  return subject.trim().toLowerCase();
+}
+
+export function buildStudentExamSubjectOrder(
+  items: ReadonlyArray<{ subject: string }>,
+) {
+  const seen = new Set<string>();
+  const orderedSubjects: string[] = [];
+
+  for (const item of items) {
+    const normalized = normalizeSubject(item.subject);
+
+    if (!normalized || seen.has(normalized)) {
+      continue;
+    }
+
+    seen.add(normalized);
+    orderedSubjects.push(normalized);
+  }
+
+  return orderedSubjects;
+}
+
+export function getStudentExamPresentation(
+  subject: string,
+  orderedSubjects?: ReadonlyArray<string>,
+): {
   subjectLabel: string;
   iconName: IconName;
   background: string;
   iconBackground: string;
+  borderColor: string;
+};
+
+export function getStudentExamPresentation(
+  subject: string,
+  orderedSubjects?: ReadonlyArray<string>,
+): {
+  subjectLabel: string;
+  iconName: IconName;
+  background: string;
+  iconBackground: string;
+  borderColor: string;
 } {
-  const normalized = subject.trim().toLowerCase();
+  const normalized = normalizeSubject(subject);
+
+  const orderedIndex = orderedSubjects?.indexOf(normalized) ?? -1;
+  const orderedPalette =
+    orderedIndex >= 0
+      ? orderedSubjectPalette[orderedIndex % orderedSubjectPalette.length]
+      : null;
 
   if (normalized === "math") {
     return {
       subjectLabel: "Математик",
       iconName: "calculator-variant-outline",
-      background: "#DFF0F8",
-      iconBackground: "#C8E4F4",
+      background: orderedPalette?.background ?? "#DFF0F8",
+      iconBackground: orderedPalette?.iconBackground ?? "#C8E4F4",
+      borderColor: orderedPalette?.borderColor ?? "#B9DDEE",
     };
   }
 
@@ -24,8 +93,9 @@ export function getStudentExamPresentation(subject: string): {
     return {
       subjectLabel: "Хими",
       iconName: "flask-outline",
-      background: "#F0E4F8",
-      iconBackground: "#E0CEFE",
+      background: orderedPalette?.background ?? "#F0E4F8",
+      iconBackground: orderedPalette?.iconBackground ?? "#E0CEFE",
+      borderColor: orderedPalette?.borderColor ?? "#D9C8F6",
     };
   }
 
@@ -33,8 +103,9 @@ export function getStudentExamPresentation(subject: string): {
     return {
       subjectLabel: "Англи",
       iconName: "book-education-outline",
-      background: "#E3F5E8",
-      iconBackground: "#C9EBD3",
+      background: orderedPalette?.background ?? "#E3F5E8",
+      iconBackground: orderedPalette?.iconBackground ?? "#C9EBD3",
+      borderColor: orderedPalette?.borderColor ?? "#BEE1C8",
     };
   }
 
@@ -42,8 +113,9 @@ export function getStudentExamPresentation(subject: string): {
     return {
       subjectLabel: "Физик",
       iconName: "atom-variant",
-      background: "#E8F1FF",
-      iconBackground: "#D5E5FF",
+      background: orderedPalette?.background ?? "#E8F1FF",
+      iconBackground: orderedPalette?.iconBackground ?? "#D5E5FF",
+      borderColor: orderedPalette?.borderColor ?? "#C8DCF8",
     };
   }
 
@@ -51,16 +123,18 @@ export function getStudentExamPresentation(subject: string): {
     return {
       subjectLabel: "Иргэний боловсрол",
       iconName: "account-school-outline",
-      background: "#F8E2EF",
-      iconBackground: "#F1CBE2",
+      background: orderedPalette?.background ?? "#F8E2EF",
+      iconBackground: orderedPalette?.iconBackground ?? "#F1CBE2",
+      borderColor: orderedPalette?.borderColor ?? "#E8BCD8",
     };
   }
 
   return {
     subjectLabel: "Нийгэм",
     iconName: "notebook-outline",
-    background: "#E8E4F8",
-    iconBackground: "#D4CEFE",
+    background: orderedPalette?.background ?? "#E8E4F8",
+    iconBackground: orderedPalette?.iconBackground ?? "#D4CEFE",
+    borderColor: orderedPalette?.borderColor ?? "#CFC6FF",
   };
 }
 


### PR DESCRIPTION
## Summary
Redesigned the student mobile exam detail/start screen to match the new reference layout while preserving the existing exam flow and tab bar.

## Changes
- Reworked the exam detail screen into a large centered pastel card layout
- Added the same `Learning MS` top header style used on the mobile home screen
- Updated the card title block to use:
  - subject text
  - topic text
  - tuned font sizes and weight
- Updated duration/task chips and schedule section layout
- Replaced the old schedule list with side-by-side:
  - `ЭХЛЭХ ЦАГ`
  - `ДУУСАХ ЦАГ`
- Restyled the warning box:
  - adjusted icon size
  - tuned text size/line height
  - reduced padding
  - reduced border radius
- Restyled the primary `Эхлэх` button to better match the web visual style:
  - kept mobile size unchanged
  - added web-like purple drop shadow
  - added bottom inset strip
  - reduced button corner radius
- Removed the bottom date line from the card
- Kept reminder behavior and start-exam logic unchanged

## Files
- `mobileAppFrontend/app/(student)/exam/[examId].tsx`

## Notes
- Tab bar was intentionally left unchanged
- Button dimensions were preserved while only visual styling changed

## Validation
- `cd mobileAppFrontend && npx tsc --noEmit` passed
