### PR TITLE
Regressions in the current mobile exam and session-integrity changes

### DIFF
--- a/cold-king-fc65/src/index.ts
+++ b/cold-king-fc65/src/index.ts
@@ -3,8 +3,15 @@ import { cors } from "hono/cors";
 import { eq } from "drizzle-orm";
 import { getCorsOrigins, type WorkerBindings } from "./config/runtime";
 import { getDb } from "./db/client";
+import { announcedExams } from "./db/schemas/announcedExams.schema";
+import { exams } from "./db/schemas/exam.schema";
 import { studentExamSessions } from "./db/schemas/student-exam-session.schema";
-import { getRequestAuth, getResolvedRequestAuth, yoga } from "./server";
+import {
+	getRequestAuth,
+	getResolvedRequestAuth,
+	resolveRequestStudentId,
+	yoga,
+} from "./server";
 
 const app = new Hono<{ Bindings: WorkerBindings }>();
 const SESSION_INTEGRITY_PATH = "/session-integrity";
@@ -104,12 +111,29 @@ app.post(SESSION_INTEGRITY_PATH, async (c) => {
 	}
 
 	const action = body;
+	const resolvedStudentId = await resolveRequestStudentId(c.req.raw, c.env, db, auth);
 
-	if (action.userId !== auth.userId) {
-		return c.json({ error: "Session user mismatch." }, 403);
+	if (!resolvedStudentId) {
+		return c.json({ error: "Student profile not found for this session." }, 403);
 	}
 
-	const sessionKey = `${action.userId}::${action.examId}`;
+	const announcedExam = await db
+		.select({ examId: announcedExams.examId })
+		.from(announcedExams)
+		.where(eq(announcedExams.id, action.examId))
+		.get();
+	const persistedExamId = announcedExam?.examId ?? action.examId;
+	const examExists = await db
+		.select({ id: exams.id })
+		.from(exams)
+		.where(eq(exams.id, persistedExamId))
+		.get();
+
+	if (!examExists) {
+		return c.json({ error: "Exam not found for this session." }, 404);
+	}
+
+	const sessionKey = `${resolvedStudentId}::${action.examId}`;
 	const now = Date.now();
 	const existing = await db
 		.select()
@@ -124,8 +148,8 @@ app.post(SESSION_INTEGRITY_PATH, async (c) => {
 
 		await db.insert(studentExamSessions).values({
 			id: sessionKey,
-			studentId: action.userId,
-			examId: action.examId,
+			studentId: resolvedStudentId,
+			examId: persistedExamId,
 			sessionId: action.sessionId,
 			deviceId: action.deviceId,
 			startedAt: action.timestamp,

--- a/cold-king-fc65/src/server.ts
+++ b/cold-king-fc65/src/server.ts
@@ -149,6 +149,33 @@ async function getMobileDemoRequestAuth(
 	};
 }
 
+export async function resolveRequestStudentId(
+	request: Request,
+	env: WorkerBindings,
+	db = getDb(env),
+	auth?: GraphQLContext["auth"],
+) {
+	const demoAuth = await getMobileDemoRequestAuth(request, env, db);
+
+	if (demoAuth?.isAuthenticated && demoAuth.userId) {
+		return demoAuth.userId;
+	}
+
+	const resolvedAuth = auth ?? (await getResolvedRequestAuth(request, env, db));
+
+	if (!resolvedAuth.isAuthenticated || !resolvedAuth.userId) {
+		return null;
+	}
+
+	const student = await db
+		.select({ id: students.id })
+		.from(students)
+		.where(eq(students.id, resolvedAuth.userId))
+		.get();
+
+	return student?.id ?? null;
+}
+
 export async function getResolvedRequestAuth(
 	request: Request,
 	env: WorkerBindings,

--- a/mobileAppFrontend/app/(student)/_layout.tsx
+++ b/mobileAppFrontend/app/(student)/_layout.tsx
@@ -19,6 +19,7 @@ export default function StudentLayout() {
       <Stack screenOptions={{ headerShown: false }}>
         <Stack.Screen name="(tabs)" />
         <Stack.Screen name="exam/[examId]" />
+        <Stack.Screen name="exam/submitted" />
         <Stack.Screen name="exam/[examId]/take" />
         <Stack.Screen name="results/[submissionId]" />
       </Stack>

--- a/mobileAppFrontend/app/(student)/exam/[examId].tsx
+++ b/mobileAppFrontend/app/(student)/exam/[examId].tsx
@@ -233,7 +233,12 @@ export default function ExamDetailScreen() {
 
           <View style={styles.scheduleRow}>
             <View style={styles.scheduleItem}>
-              <View style={styles.scheduleAccent} />
+              <View
+                style={[
+                  styles.scheduleAccent,
+                  { backgroundColor: presentation?.accentColor ?? "#C7BEFF" },
+                ]}
+              />
               <View>
                 <Text style={styles.scheduleLabel}>ЭХЛЭХ ЦАГ</Text>
                 <Text style={styles.scheduleValue}>{formatScheduledTime(exam.startTime)}</Text>
@@ -241,7 +246,12 @@ export default function ExamDetailScreen() {
             </View>
 
             <View style={styles.scheduleItem}>
-              <View style={styles.scheduleAccent} />
+              <View
+                style={[
+                  styles.scheduleAccent,
+                  { backgroundColor: presentation?.accentColor ?? "#C7BEFF" },
+                ]}
+              />
               <View>
                 <Text style={styles.scheduleLabel}>ДУУСАХ ЦАГ</Text>
                 <Text style={styles.scheduleValue}>
@@ -251,7 +261,15 @@ export default function ExamDetailScreen() {
             </View>
           </View>
 
-          <View style={styles.noticeBox}>
+          <View
+            style={[
+              styles.noticeBox,
+              {
+                backgroundColor: presentation?.noticeBackground ?? "#F3F0FF",
+                borderColor: presentation?.noticeBorder ?? "#D8D1FA",
+              },
+            ]}
+          >
             <Ionicons name="information-circle-outline" size={22} color={colors.textPrimary} />
             <Text style={styles.noticeText}>
               Шалгалтын үед хяналт болон хамгаалалтын функцууд идэвхтэй ажиллана.
@@ -282,15 +300,31 @@ export default function ExamDetailScreen() {
             <View
               style={[
                 styles.startActionShell,
+                {
+                  shadowColor: presentation?.actionButtonBackground ?? "#9E81F0",
+                },
                 isExamLoading || exam.questionCount === 0 ? styles.startActionDisabled : null,
               ]}
             >
               <Pressable
-                style={styles.startAction}
+                style={[
+                  styles.startAction,
+                  {
+                    backgroundColor: presentation?.actionButtonBackground ?? "#9E81F0",
+                  },
+                ]}
                 onPress={() => void handleStartPress()}
                 disabled={isExamLoading || exam.questionCount === 0}
               >
-                <View pointerEvents="none" style={styles.startActionInset} />
+                <View
+                  pointerEvents="none"
+                  style={[
+                    styles.startActionInset,
+                    {
+                      backgroundColor: presentation?.actionButtonInset ?? "rgba(103, 79, 184, 0.38)",
+                    },
+                  ]}
+                />
                 {isExamLoading ? (
                   <ActivityIndicator color="#FFFFFF" />
                 ) : (
@@ -349,8 +383,9 @@ const styles = StyleSheet.create({
   },
   card: {
     alignSelf: "center",
-    width: 350,
-    height: 407,
+    width: "100%",
+    maxWidth: 350,
+    minHeight: 407,
     borderRadius: 34,
     borderWidth: 1,
     borderColor: "#CEC8FF",
@@ -430,9 +465,8 @@ const styles = StyleSheet.create({
   },
   noticeBox: {
     marginTop: 26,
-    alignSelf: "center",
-    width: 302,
-    height: 96,
+    width: "100%",
+    minHeight: 96,
     borderRadius: 16,
     borderWidth: 1,
     borderColor: "#D6D1F7",
@@ -480,7 +514,6 @@ const styles = StyleSheet.create({
     width: 142,
     height: 44,
     borderRadius: 18,
-    shadowColor: "#9E81F0",
     shadowOpacity: 0.22,
     shadowRadius: 8,
     shadowOffset: {
@@ -495,7 +528,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     borderRadius: 18,
-    backgroundColor: "#9E81F0",
     overflow: "hidden",
   },
   startActionInset: {

--- a/mobileAppFrontend/app/(student)/exam/[examId]/take.tsx
+++ b/mobileAppFrontend/app/(student)/exam/[examId]/take.tsx
@@ -1,20 +1,23 @@
 import { Ionicons } from "@expo/vector-icons";
 import { Stack, router, useLocalSearchParams } from "expo-router";
 import { useKeepAwake } from "expo-keep-awake";
-import { useEffect, useMemo, useRef, useState } from "react";
-import { Alert, Pressable, ScrollView, StyleSheet, View } from "react-native";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ActivityIndicator, Alert, Pressable, ScrollView, StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useAppData } from "@/data/app-data";
 import { MathText } from "@/components/MathText";
 import { SecurityOverlay } from "@/components/SecurityOverlay";
 import { SecureText } from "@/components/SecureText";
 import { FullScreenLoader } from "@/components/FullScreenLoader";
-import { PrimaryButton } from "@/components/PrimaryButton";
 import { StatusCard } from "@/components/StatusCard";
 import { clearExamDraft, getExamDraft, saveExamDraft } from "@/lib/exam-draft";
 import { colors, fonts, shadows } from "@/lib/theme";
 import type { StudentAnswerDraft } from "@/lib/student-types";
-import { formatCountdown } from "@/lib/student-exam";
+import {
+  buildStudentExamSubjectOrder,
+  formatCountdown,
+  getStudentExamPresentation,
+} from "@/lib/student-exam";
 import { shuffleQuestionsForUser } from "@/security/question-order";
 import { useExamIntegrity } from "@/security/useExamIntegrity";
 
@@ -26,7 +29,7 @@ function getRemainingSeconds(durationMinutes: number, startedAt: number) {
 export default function TakeExamScreen() {
   const params = useLocalSearchParams<{ examId: string }>();
   const examId = typeof params.examId === "string" ? params.examId : "";
-  const { ensureExamLoaded, getExamById, submitExam, student } = useAppData();
+  const { availableExams, ensureExamLoaded, getExamById, submitExam, student } = useAppData();
   const [secondsLeft, setSecondsLeft] = useState(0);
   const [answers, setAnswers] = useState<Record<string, StudentAnswerDraft>>({});
   const [submitError, setSubmitError] = useState("");
@@ -42,6 +45,14 @@ export default function TakeExamScreen() {
     (source: "manual" | "auto" | "background" | "session_replaced") => Promise<void>
   >(async () => {});
   const exam = getExamById(examId);
+  const subjectOrder = useMemo(
+    () => buildStudentExamSubjectOrder(exam ? [...availableExams, exam] : availableExams),
+    [availableExams, exam],
+  );
+  const presentation = useMemo(
+    () => (exam ? getStudentExamPresentation(exam.subject, subjectOrder) : null),
+    [exam, subjectOrder],
+  );
 
   const shuffledQuestions = useMemo(
     () => (exam ? shuffleQuestionsForUser(exam.questions, student.email, exam.id) : []),
@@ -53,25 +64,25 @@ export default function TakeExamScreen() {
     [answers, shuffledQuestions],
   );
 
-  useKeepAwake();
-
-  const {
-    leaveCount,
-    screenshotCount,
-    recordingCount,
-    violationCount,
-    warningMessage,
-    recordingBlurActive,
-    faceStatus,
-    nativeMonitoringAvailable,
-  } = useExamIntegrity({
-    userId: student.id,
-    examId,
-    onAutoSubmit: async (reason) => {
+  const handleAutoSubmit = useCallback(
+    async (reason: "timer" | "background" | "session_replaced") => {
       await submitExamRef.current(
         reason === "timer" ? "auto" : reason === "session_replaced" ? "session_replaced" : "background",
       );
     },
+    [],
+  );
+
+  useKeepAwake();
+
+  const {
+    leaveCount,
+    warningMessage,
+    recordingBlurActive,
+  } = useExamIntegrity({
+    userId: student.id,
+    examId,
+    onAutoSubmit: handleAutoSubmit,
   });
 
   useEffect(() => {
@@ -193,7 +204,7 @@ export default function TakeExamScreen() {
       });
 
       await clearExamDraft(exam.id);
-      router.replace("/(student)/(tabs)/results");
+      router.replace("/(student)/exam/submitted");
     } catch (caughtError) {
       setSubmitError(
         caughtError instanceof Error
@@ -302,14 +313,22 @@ export default function TakeExamScreen() {
       ) : null}
 
       <View style={styles.header}>
-        <View>
-          <SecureText style={styles.headerEyebrow}>Хамгаалалттай шалгалт</SecureText>
-          <SecureText style={styles.headerTitle}>Шалгалт явагдаж байна</SecureText>
-        </View>
-        <View style={[styles.timerChip, secondsLeft < 300 ? styles.timerChipDanger : null]}>
+        <SecureText style={styles.headerTitle}>
+          {presentation?.subjectLabel ?? exam.subject}
+        </SecureText>
+        <View
+          style={[
+            styles.timerChip,
+            {
+              backgroundColor: presentation?.noticeBackground ?? "#F3F0FF",
+              borderColor: presentation?.noticeBorder ?? "#D8D1FA",
+            },
+            secondsLeft < 300 ? styles.timerChipDanger : null,
+          ]}
+        >
           <Ionicons
             name="time-outline"
-            size={16}
+            size={20}
             color={secondsLeft < 300 ? colors.dangerText : colors.textSecondary}
           />
           <SecureText style={[styles.timerText, secondsLeft < 300 ? styles.timerTextDanger : null]}>
@@ -319,19 +338,6 @@ export default function TakeExamScreen() {
       </View>
 
       <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
-        <MathText value={exam.title} style={styles.title} />
-        <SecureText style={styles.subtitle}>
-          Бүх асуулт нэг дор харагдана. Доош гүйлгээд хариулаад, дуусмагц шалгалтаа илгээнэ үү.
-        </SecureText>
-
-        <StatusCard
-          tone="info"
-          message={
-            nativeMonitoringAvailable
-              ? "Дэлгэцийн зураг, аппаас гарах, бичлэг, нүүр илрүүлэлт зэрэг хяналт идэвхтэй."
-              : "Дэлгэцийн зураг болон аппаас гарах хамгаалалт идэвхтэй. Нүүр болон бичлэгийн төхөөрөмжийн түвшний хяналт нь хөгжүүлэлтийн хувилбар дээр идэвхжинэ."
-          }
-        />
         {leaveCount > 0 ? (
           <StatusCard
             tone="warning"
@@ -339,48 +345,6 @@ export default function TakeExamScreen() {
           />
         ) : null}
         {submitError ? <StatusCard tone="error" message={submitError} /> : null}
-
-        <View style={styles.progressCard}>
-          <View>
-            <SecureText style={styles.progressValue}>{answeredCount}</SecureText>
-            <SecureText style={styles.progressLabel}>Бөглөсөн</SecureText>
-          </View>
-          <View>
-            <SecureText style={styles.progressValue}>{shuffledQuestions.length - answeredCount}</SecureText>
-            <SecureText style={styles.progressLabel}>Үлдсэн</SecureText>
-          </View>
-          <View>
-            <SecureText style={styles.progressValue}>{violationCount}</SecureText>
-            <SecureText style={styles.progressLabel}>Зөрчил</SecureText>
-          </View>
-        </View>
-
-        <View style={styles.securityMetaCard}>
-          <View style={styles.securityMetaRow}>
-            <SecureText style={styles.securityMetaLabel}>Нийт асуулт</SecureText>
-            <SecureText style={styles.securityMetaValue}>{shuffledQuestions.length}</SecureText>
-          </View>
-          <View style={styles.securityMetaRow}>
-            <SecureText style={styles.securityMetaLabel}>Дэлгэцийн зураг</SecureText>
-            <SecureText style={styles.securityMetaValue}>{screenshotCount}</SecureText>
-          </View>
-          <View style={styles.securityMetaRow}>
-            <SecureText style={styles.securityMetaLabel}>Бичлэг</SecureText>
-            <SecureText style={styles.securityMetaValue}>{recordingCount}</SecureText>
-          </View>
-          <View style={styles.securityMetaRow}>
-            <SecureText style={styles.securityMetaLabel}>Нүүрний төлөв</SecureText>
-            <SecureText style={styles.securityMetaValue}>
-              {faceStatus === "unsupported"
-                ? "Боломжгүй"
-                : faceStatus === "single_face"
-                  ? "Нэг нүүр"
-                  : faceStatus === "multiple_faces"
-                    ? "Олон нүүр"
-                    : "Нүүр алга"}
-            </SecureText>
-          </View>
-        </View>
 
         <View style={styles.questionStack}>
           {shuffledQuestions.map((question, index) => (
@@ -402,9 +366,6 @@ export default function TakeExamScreen() {
                       style={[styles.choiceButton, selected ? styles.choiceButtonSelected : null]}
                       onPress={() => handleSelectChoice(question.id, choice.id)}
                     >
-                      <View style={[styles.radio, selected ? styles.radioSelected : null]}>
-                        {selected ? <View style={styles.radioInner} /> : null}
-                      </View>
                       <MathText value={`${choice.label}. ${choice.text}`} style={styles.choiceText} />
                     </Pressable>
                   );
@@ -414,12 +375,41 @@ export default function TakeExamScreen() {
           ))}
         </View>
 
-        <PrimaryButton
-          label={submitLoading ? "Илгээж байна..." : "Шалгалт илгээх"}
-          onPress={handleSubmitPress}
-          disabled={submitLoading}
-          loading={submitLoading}
-        />
+        <View style={styles.footer}>
+          <View style={styles.progressChip}>
+            <SecureText style={styles.progressChipText}>
+              {answeredCount}/{shuffledQuestions.length} бөглөсөн
+            </SecureText>
+          </View>
+
+          <Pressable
+            style={[
+              styles.submitButton,
+              {
+                backgroundColor: presentation?.actionButtonBackground ?? colors.primary,
+              },
+              submitLoading ? styles.submitButtonDisabled : null,
+            ]}
+            onPress={handleSubmitPress}
+            disabled={submitLoading}
+          >
+            <View
+              pointerEvents="none"
+              style={[
+                styles.submitButtonInset,
+                {
+                  backgroundColor:
+                    presentation?.actionButtonInset ?? "rgba(103, 79, 184, 0.38)",
+                },
+              ]}
+            />
+            {submitLoading ? (
+              <ActivityIndicator color="#FFFFFF" />
+            ) : (
+              <SecureText style={styles.submitButtonText}>Илгээх</SecureText>
+            )}
+          </Pressable>
+        </View>
       </ScrollView>
     </SafeAreaView>
   );
@@ -428,23 +418,19 @@ export default function TakeExamScreen() {
 const styles = StyleSheet.create({
   page: {
     flex: 1,
-    backgroundColor: colors.pageBackground,
+    backgroundColor: "#FFFFFF",
   },
   header: {
     paddingHorizontal: 20,
     paddingTop: 12,
-    paddingBottom: 8,
+    paddingBottom: 20,
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-  },
-  headerEyebrow: {
-    fontFamily: fonts.sans.medium,
-    fontSize: 12,
-    color: colors.primary,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
   },
   headerTitle: {
-    marginTop: 6,
     fontFamily: fonts.display.semibold,
     fontSize: 22,
     color: colors.textPrimary,
@@ -453,12 +439,10 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: 8,
-    borderRadius: 999,
-    backgroundColor: colors.surface,
-    paddingHorizontal: 14,
+    borderRadius: 22,
+    paddingHorizontal: 18,
     paddingVertical: 10,
     borderWidth: 1,
-    borderColor: colors.border,
   },
   timerChipDanger: {
     borderColor: colors.dangerBorder,
@@ -466,7 +450,7 @@ const styles = StyleSheet.create({
   },
   timerText: {
     fontFamily: fonts.display.semibold,
-    fontSize: 15,
+    fontSize: 18,
     color: colors.textPrimary,
   },
   timerTextDanger: {
@@ -474,80 +458,19 @@ const styles = StyleSheet.create({
   },
   content: {
     paddingHorizontal: 20,
-    paddingTop: 10,
-    paddingBottom: 120,
-  },
-  title: {
-    fontFamily: fonts.display.semibold,
-    fontSize: 27,
-    color: colors.textPrimary,
-  },
-  subtitle: {
-    marginTop: 8,
-    marginBottom: 18,
-    fontFamily: fonts.sans.regular,
-    fontSize: 14,
-    lineHeight: 22,
-    color: colors.textMuted,
-  },
-  progressCard: {
-    marginBottom: 16,
-    flexDirection: "row",
-    justifyContent: "space-between",
-    borderRadius: 24,
-    borderWidth: 1,
-    borderColor: colors.border,
-    backgroundColor: colors.surface,
-    paddingHorizontal: 18,
-    paddingVertical: 16,
-    ...shadows.card,
-  },
-  progressValue: {
-    textAlign: "center",
-    fontFamily: fonts.display.semibold,
-    fontSize: 22,
-    color: colors.textPrimary,
-  },
-  progressLabel: {
-    marginTop: 6,
-    textAlign: "center",
-    fontFamily: fonts.sans.medium,
-    fontSize: 12,
-    color: colors.textMuted,
-  },
-  securityMetaCard: {
-    marginBottom: 16,
-    borderRadius: 24,
-    backgroundColor: colors.surface,
-    paddingHorizontal: 18,
-    paddingVertical: 10,
-    ...shadows.card,
-  },
-  securityMetaRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    paddingVertical: 9,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.border,
-  },
-  securityMetaLabel: {
-    fontFamily: fonts.sans.medium,
-    fontSize: 13,
-    color: colors.textMuted,
-  },
-  securityMetaValue: {
-    fontFamily: fonts.sans.semibold,
-    fontSize: 14,
-    color: colors.textPrimary,
+    paddingTop: 22,
+    paddingBottom: 110,
   },
   questionStack: {
-    gap: 16,
+    gap: 22,
   },
   questionCard: {
-    borderRadius: 28,
-    backgroundColor: colors.surface,
-    padding: 18,
+    borderRadius: 26,
+    borderWidth: 1,
+    borderColor: "#E9E3F8",
+    backgroundColor: "#FFFFFF",
+    paddingHorizontal: 22,
+    paddingVertical: 22,
     ...shadows.card,
   },
   questionHeader: {
@@ -558,63 +481,85 @@ const styles = StyleSheet.create({
   },
   questionCounter: {
     fontFamily: fonts.sans.medium,
-    fontSize: 12,
-    color: colors.primary,
+    fontSize: 16,
+    color: colors.textMuted,
   },
   questionPoints: {
     fontFamily: fonts.sans.medium,
-    fontSize: 12,
-    color: colors.textSoft,
+    fontSize: 16,
+    color: colors.textMuted,
   },
   questionTitle: {
-    marginTop: 12,
+    marginTop: 16,
     fontFamily: fonts.sans.semibold,
-    fontSize: 17,
-    lineHeight: 25,
+    fontSize: 18,
+    lineHeight: 28,
     color: colors.textPrimary,
   },
   choiceList: {
-    marginTop: 16,
-    gap: 10,
+    marginTop: 18,
+    gap: 14,
   },
   choiceButton: {
-    flexDirection: "row",
-    gap: 12,
+    justifyContent: "center",
     borderRadius: 18,
     borderWidth: 1,
-    borderColor: colors.border,
-    backgroundColor: colors.surface,
-    paddingHorizontal: 14,
-    paddingVertical: 14,
+    borderColor: "#E7E1F6",
+    backgroundColor: "#FFFFFF",
+    paddingHorizontal: 18,
+    paddingVertical: 16,
   },
   choiceButtonSelected: {
-    borderColor: colors.primary,
-    backgroundColor: "#F6F2FF",
-  },
-  radio: {
-    marginTop: 2,
-    height: 22,
-    width: 22,
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: 999,
-    borderWidth: 1.5,
-    borderColor: colors.borderStrong,
-  },
-  radioSelected: {
-    borderColor: colors.primary,
-  },
-  radioInner: {
-    height: 10,
-    width: 10,
-    borderRadius: 999,
-    backgroundColor: colors.primary,
+    borderColor: "#DCD4FA",
+    backgroundColor: "#ECEAFF",
   },
   choiceText: {
-    flex: 1,
+    fontFamily: fonts.sans.medium,
+    fontSize: 16,
+    lineHeight: 24,
+    color: colors.textPrimary,
+  },
+  footer: {
+    marginTop: 28,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+  },
+  progressChip: {
+    borderRadius: 999,
+    backgroundColor: "#F3F0FF",
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+  },
+  progressChipText: {
     fontFamily: fonts.sans.medium,
     fontSize: 14,
-    lineHeight: 22,
     color: colors.textPrimary,
+  },
+  submitButton: {
+    width: 132,
+    height: 44,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 18,
+    overflow: "hidden",
+  },
+  submitButtonInset: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: 5,
+    borderBottomLeftRadius: 18,
+    borderBottomRightRadius: 18,
+  },
+  submitButtonText: {
+    fontFamily: fonts.display.semibold,
+    fontSize: 16,
+    color: "#FFFFFF",
+  },
+  submitButtonDisabled: {
+    opacity: 0.6,
   },
 });

--- a/mobileAppFrontend/app/(student)/exam/submitted.tsx
+++ b/mobileAppFrontend/app/(student)/exam/submitted.tsx
@@ -1,0 +1,145 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Stack, router } from "expo-router";
+import { useEffect } from "react";
+import { Image, StyleSheet, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { colors, fonts, shadows } from "@/lib/theme";
+
+const learningMsLogo = require("../../../assets/learning-ms-logo.png");
+const REDIRECT_DELAY_MS = 2200;
+
+export default function ExamSubmittedScreen() {
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      router.replace("/(student)/(tabs)/results");
+    }, REDIRECT_DELAY_MS);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, []);
+
+  return (
+    <SafeAreaView edges={["top", "left", "right"]} style={styles.page}>
+      <Stack.Screen
+        options={{
+          gestureEnabled: false,
+        }}
+      />
+
+      <View style={styles.header}>
+        <View style={styles.brandMarkWrap}>
+          <Image source={learningMsLogo} style={styles.brandImage} resizeMode="contain" />
+        </View>
+        <View>
+          <Text style={styles.brandTop}>Learning</Text>
+          <Text style={styles.brandBottom}>MS</Text>
+        </View>
+      </View>
+
+      <View style={styles.content}>
+        <View style={styles.card}>
+          <View style={styles.iconOuter}>
+            <View style={styles.iconInner}>
+              <Ionicons name="checkmark-circle-outline" size={28} color={colors.primary} />
+            </View>
+          </View>
+
+          <Text style={styles.title}>Шалгалт амжилттай илгээгдлээ</Text>
+          <Text style={styles.description}>
+            Үр дүнг хугацаа дууссаны дараа харах боломжтой
+          </Text>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  page: {
+    flex: 1,
+    backgroundColor: "#FFFFFF",
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    paddingHorizontal: 24,
+    paddingBottom: 18,
+    paddingTop: 10,
+    backgroundColor: "#FFFFFF",
+  },
+  brandMarkWrap: {
+    height: 32,
+    width: 43,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  brandImage: {
+    width: 43,
+    height: 32,
+  },
+  brandTop: {
+    fontFamily: fonts.display.medium,
+    fontSize: 19,
+    color: colors.textPrimary,
+  },
+  brandBottom: {
+    marginTop: -2,
+    fontFamily: fonts.display.medium,
+    fontSize: 19,
+    color: colors.textPrimary,
+  },
+  content: {
+    flex: 1,
+    justifyContent: "center",
+    paddingHorizontal: 20,
+    paddingBottom: 180,
+  },
+  card: {
+    alignSelf: "center",
+    width: "100%",
+    maxWidth: 350,
+    borderRadius: 28,
+    borderWidth: 1,
+    borderColor: "#D7D0FF",
+    backgroundColor: "#F7F4FF",
+    paddingHorizontal: 28,
+    paddingTop: 22,
+    paddingBottom: 28,
+    ...shadows.card,
+  },
+  iconOuter: {
+    height: 82,
+    width: 82,
+    borderRadius: 41,
+    backgroundColor: "#E8E0FF",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  iconInner: {
+    height: 52,
+    width: 52,
+    borderRadius: 26,
+    backgroundColor: "#F4EEFF",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  title: {
+    marginTop: 24,
+    fontFamily: fonts.display.semibold,
+    fontSize: 22,
+    lineHeight: 30,
+    color: colors.textPrimary,
+  },
+  description: {
+    marginTop: 18,
+    maxWidth: 280,
+    fontFamily: fonts.sans.regular,
+    fontSize: 16,
+    lineHeight: 24,
+    color: "#8F8A99",
+  },
+});

--- a/mobileAppFrontend/src/lib/student-exam.ts
+++ b/mobileAppFrontend/src/lib/student-exam.ts
@@ -8,21 +8,45 @@ const orderedSubjectPalette = [
     background: "#E8E4F8",
     iconBackground: "#D4CEFE",
     borderColor: "#CFC6FF",
+    accentColor: "#C7BEFF",
+    noticeBackground: "#F3F0FF",
+    noticeBorder: "#D8D1FA",
+    actionButtonBackground: "#9E81F0",
+    actionButtonInset: "rgba(103, 79, 184, 0.38)",
+    actionButtonShadow: "rgba(158, 129, 240, 0.22)",
   },
   {
     background: "#DFF0F8",
     iconBackground: "#C8E4F4",
     borderColor: "#B9DDEE",
+    accentColor: "#AFCFE6",
+    noticeBackground: "#EEF6FB",
+    noticeBorder: "#C7E0EE",
+    actionButtonBackground: "#6C95EA",
+    actionButtonInset: "rgba(66, 105, 185, 0.38)",
+    actionButtonShadow: "rgba(108, 149, 234, 0.24)",
   },
   {
     background: "#F8E2EF",
     iconBackground: "#F1CBE2",
     borderColor: "#E8BCD8",
+    accentColor: "#E3B6D2",
+    noticeBackground: "#FCEFFA",
+    noticeBorder: "#EFC9E3",
+    actionButtonBackground: "#D98AEF",
+    actionButtonInset: "rgba(170, 93, 191, 0.38)",
+    actionButtonShadow: "rgba(217, 138, 239, 0.24)",
   },
   {
     background: "#E3F5E8",
     iconBackground: "#C9EBD3",
     borderColor: "#BEE1C8",
+    accentColor: "#AFD7BB",
+    noticeBackground: "#EFF9F2",
+    noticeBorder: "#CDE6D5",
+    actionButtonBackground: "#69B88A",
+    actionButtonInset: "rgba(74, 132, 97, 0.34)",
+    actionButtonShadow: "rgba(105, 184, 138, 0.22)",
   },
 ] as const;
 
@@ -59,6 +83,12 @@ export function getStudentExamPresentation(
   background: string;
   iconBackground: string;
   borderColor: string;
+  accentColor: string;
+  noticeBackground: string;
+  noticeBorder: string;
+  actionButtonBackground: string;
+  actionButtonInset: string;
+  actionButtonShadow: string;
 };
 
 export function getStudentExamPresentation(
@@ -70,6 +100,12 @@ export function getStudentExamPresentation(
   background: string;
   iconBackground: string;
   borderColor: string;
+  accentColor: string;
+  noticeBackground: string;
+  noticeBorder: string;
+  actionButtonBackground: string;
+  actionButtonInset: string;
+  actionButtonShadow: string;
 } {
   const normalized = normalizeSubject(subject);
 
@@ -86,6 +122,12 @@ export function getStudentExamPresentation(
       background: orderedPalette?.background ?? "#DFF0F8",
       iconBackground: orderedPalette?.iconBackground ?? "#C8E4F4",
       borderColor: orderedPalette?.borderColor ?? "#B9DDEE",
+      accentColor: orderedPalette?.accentColor ?? "#AFCFE6",
+      noticeBackground: orderedPalette?.noticeBackground ?? "#EEF6FB",
+      noticeBorder: orderedPalette?.noticeBorder ?? "#C7E0EE",
+      actionButtonBackground: orderedPalette?.actionButtonBackground ?? "#6C95EA",
+      actionButtonInset: orderedPalette?.actionButtonInset ?? "rgba(66, 105, 185, 0.38)",
+      actionButtonShadow: orderedPalette?.actionButtonShadow ?? "rgba(108, 149, 234, 0.24)",
     };
   }
 
@@ -96,6 +138,12 @@ export function getStudentExamPresentation(
       background: orderedPalette?.background ?? "#F0E4F8",
       iconBackground: orderedPalette?.iconBackground ?? "#E0CEFE",
       borderColor: orderedPalette?.borderColor ?? "#D9C8F6",
+      accentColor: orderedPalette?.accentColor ?? "#C7BEFF",
+      noticeBackground: orderedPalette?.noticeBackground ?? "#F3F0FF",
+      noticeBorder: orderedPalette?.noticeBorder ?? "#D8D1FA",
+      actionButtonBackground: orderedPalette?.actionButtonBackground ?? "#9E81F0",
+      actionButtonInset: orderedPalette?.actionButtonInset ?? "rgba(103, 79, 184, 0.38)",
+      actionButtonShadow: orderedPalette?.actionButtonShadow ?? "rgba(158, 129, 240, 0.22)",
     };
   }
 
@@ -106,6 +154,12 @@ export function getStudentExamPresentation(
       background: orderedPalette?.background ?? "#E3F5E8",
       iconBackground: orderedPalette?.iconBackground ?? "#C9EBD3",
       borderColor: orderedPalette?.borderColor ?? "#BEE1C8",
+      accentColor: orderedPalette?.accentColor ?? "#AFD7BB",
+      noticeBackground: orderedPalette?.noticeBackground ?? "#EFF9F2",
+      noticeBorder: orderedPalette?.noticeBorder ?? "#CDE6D5",
+      actionButtonBackground: orderedPalette?.actionButtonBackground ?? "#69B88A",
+      actionButtonInset: orderedPalette?.actionButtonInset ?? "rgba(74, 132, 97, 0.34)",
+      actionButtonShadow: orderedPalette?.actionButtonShadow ?? "rgba(105, 184, 138, 0.22)",
     };
   }
 
@@ -116,6 +170,12 @@ export function getStudentExamPresentation(
       background: orderedPalette?.background ?? "#E8F1FF",
       iconBackground: orderedPalette?.iconBackground ?? "#D5E5FF",
       borderColor: orderedPalette?.borderColor ?? "#C8DCF8",
+      accentColor: orderedPalette?.accentColor ?? "#AFCFE6",
+      noticeBackground: orderedPalette?.noticeBackground ?? "#EEF6FB",
+      noticeBorder: orderedPalette?.noticeBorder ?? "#C7E0EE",
+      actionButtonBackground: orderedPalette?.actionButtonBackground ?? "#6C95EA",
+      actionButtonInset: orderedPalette?.actionButtonInset ?? "rgba(66, 105, 185, 0.38)",
+      actionButtonShadow: orderedPalette?.actionButtonShadow ?? "rgba(108, 149, 234, 0.24)",
     };
   }
 
@@ -126,6 +186,12 @@ export function getStudentExamPresentation(
       background: orderedPalette?.background ?? "#F8E2EF",
       iconBackground: orderedPalette?.iconBackground ?? "#F1CBE2",
       borderColor: orderedPalette?.borderColor ?? "#E8BCD8",
+      accentColor: orderedPalette?.accentColor ?? "#E3B6D2",
+      noticeBackground: orderedPalette?.noticeBackground ?? "#FCEFFA",
+      noticeBorder: orderedPalette?.noticeBorder ?? "#EFC9E3",
+      actionButtonBackground: orderedPalette?.actionButtonBackground ?? "#D98AEF",
+      actionButtonInset: orderedPalette?.actionButtonInset ?? "rgba(170, 93, 191, 0.38)",
+      actionButtonShadow: orderedPalette?.actionButtonShadow ?? "rgba(217, 138, 239, 0.24)",
     };
   }
 
@@ -135,6 +201,12 @@ export function getStudentExamPresentation(
     background: orderedPalette?.background ?? "#E8E4F8",
     iconBackground: orderedPalette?.iconBackground ?? "#D4CEFE",
     borderColor: orderedPalette?.borderColor ?? "#CFC6FF",
+    accentColor: orderedPalette?.accentColor ?? "#C7BEFF",
+    noticeBackground: orderedPalette?.noticeBackground ?? "#F3F0FF",
+    noticeBorder: orderedPalette?.noticeBorder ?? "#D8D1FA",
+    actionButtonBackground: orderedPalette?.actionButtonBackground ?? "#9E81F0",
+    actionButtonInset: orderedPalette?.actionButtonInset ?? "rgba(103, 79, 184, 0.38)",
+    actionButtonShadow: orderedPalette?.actionButtonShadow ?? "rgba(158, 129, 240, 0.22)",
   };
 }
 

--- a/mobileAppFrontend/src/security/session-integrity.ts
+++ b/mobileAppFrontend/src/security/session-integrity.ts
@@ -33,6 +33,10 @@ type CreateSessionIntegrityOptions = {
   onSessionReplaced: () => void;
 };
 
+function isPermanentSessionError(status: number) {
+  return status === 400 || status === 401 || status === 403 || status === 404;
+}
+
 function buildRandomId(prefix: string) {
   const randomPart =
     globalThis.crypto?.randomUUID?.() ??
@@ -122,6 +126,10 @@ async function postSessionAction(action: SessionAction): Promise<SessionBackendS
     });
 
     if (!response.ok) {
+      if (isPermanentSessionError(response.status)) {
+        return "skipped";
+      }
+
       await enqueueAction(action);
       return "queued_offline";
     }
@@ -158,6 +166,10 @@ async function flushQueuedActions() {
       });
 
       if (!response.ok) {
+        if (isPermanentSessionError(response.status)) {
+          continue;
+        }
+
         remaining.push(action);
         continue;
       }
@@ -218,7 +230,13 @@ export function createSessionIntegrity({ userId, examId, onSessionReplaced }: Cr
 
     inFlight = true;
     try {
-      await sendAction("heartbeat");
+      const status = await sendAction("heartbeat");
+
+      if (status === "skipped" && heartbeatTimer) {
+        clearInterval(heartbeatTimer);
+        heartbeatTimer = null;
+        stopped = true;
+      }
     } finally {
       inFlight = false;
     }
@@ -228,7 +246,7 @@ export function createSessionIntegrity({ userId, examId, onSessionReplaced }: Cr
     async start() {
       const status = await sendAction("start");
 
-      if (stopped || status === "replaced_by_other_device") {
+      if (stopped || status === "replaced_by_other_device" || status === "skipped") {
         return status;
       }
 


### PR DESCRIPTION
## Summary

Reviewing the local changes since `origin/main`, I found two regressions that should be fixed before these changes are pushed.

## Findings

### 1. High: session integrity can silently disable itself on 4xx responses

The mobile client now treats `400/401/403/404` from `/session-integrity` as `skipped`, and then stops heartbeats entirely.

Relevant code:
- `mobileAppFrontend/src/security/session-integrity.ts`
- `cold-king-fc65/src/index.ts`

Details:
- In `mobileAppFrontend/src/security/session-integrity.ts`, non-OK responses that match `isPermanentSessionError()` return `skipped`.
- `heartbeat()` clears the timer and sets `stopped = true` when it sees `skipped`.
- `start()` also exits early on `skipped`.
- At the same time, the backend now explicitly returns `403` when the student profile cannot be resolved and `404` when the exam mapping cannot be resolved.

Why this is a bug:
- A stale announced-exam id, profile mismatch, or backend data inconsistency now turns off single-device session protection for the rest of the exam attempt.
- This fails open instead of failing closed or degrading to offline queueing.
- The user can continue the exam while session replacement detection is no longer running.

Suggested fix:
- Do not permanently stop heartbeats on these responses.
- Either keep queueing and retrying, or block exam start with a visible error instead of silently disabling integrity.

### 2. Medium: the take-exam screen no longer shows the exam title

Relevant code:
- `mobileAppFrontend/app/(student)/exam/[examId]/take.tsx`

Details:
- The redesigned take screen now renders only the subject label in the header.
- The previous `exam.title` block was removed and is no longer shown anywhere on the screen.

Why this is a bug:
- If a student has multiple active exams under the same subject, they cannot verify which exact exam they are currently taking after entering the attempt screen.
- This is a UX regression from the previous implementation, which clearly showed the exam title.

Suggested fix:
- Render `exam.title` again near the header or at the top of the scroll content.
