### PR TITLE
move mobile student classroom assignment from env config to DB-backed…

### DIFF
--- a/cold-king-fc65/src/graphql/resolvers/mutations/student.mutations.ts
+++ b/cold-king-fc65/src/graphql/resolvers/mutations/student.mutations.ts
@@ -7,6 +7,7 @@ import type { GraphQLContext } from "../../../server";
 import {
 	getAccessibleExamForStudent,
 	loadQuestionsWithChoices,
+	requireStudentRecord,
 } from "../student-exam.helpers";
 import { assertAuthenticated, badUserInputError } from "../../errors";
 
@@ -94,6 +95,40 @@ export const studentMutation = {
 					id: userId,
 					...values,
 				})
+				.returning()
+				.get();
+		},
+		changeStudentClassroom: async (
+			_: unknown,
+			args: {
+				input: {
+					inviteCode: string;
+				};
+			},
+			context: GraphQLContext,
+		) => {
+			const student = await requireStudentRecord(context);
+			const normalizedCode = args.input.inviteCode.trim().toUpperCase();
+			const classroom = await context.db
+				.select()
+				.from(classrooms)
+				.where(eq(classrooms.classCode, normalizedCode))
+				.get();
+
+			if (!classroom) {
+				throw badUserInputError("Invalid class code.");
+			}
+
+			return context.db
+				.update(students)
+				.set({
+					grade: getGradeFromClassName(classroom.className),
+					className: classroom.className,
+					inviteCode: classroom.classCode,
+					classroomId: classroom.id,
+					teacherId: classroom.teacherId,
+				})
+				.where(eq(students.id, student.id))
 				.returning()
 				.get();
 		},

--- a/cold-king-fc65/src/graphql/schemas/student.schema.ts
+++ b/cold-king-fc65/src/graphql/schemas/student.schema.ts
@@ -119,6 +119,10 @@ export const studentTypeDefs = gql`
 		inviteCode: String!
 	}
 
+	input ChangeStudentClassroomInput {
+		inviteCode: String!
+	}
+
 	input StudentExamAnswerInput {
 		questionId: String!
 		selectedChoiceId: String
@@ -133,6 +137,7 @@ export const studentTypeDefs = gql`
 
 	type Mutation {
 		upsertStudent(input: upsertStudentInput!): Student
+		changeStudentClassroom(input: ChangeStudentClassroomInput!): Student!
 		submitStudentExam(input: SubmitStudentExamInput!): StudentExamSubmission!
 	}
 `;

--- a/cold-king-fc65/src/server.ts
+++ b/cold-king-fc65/src/server.ts
@@ -81,7 +81,24 @@ async function getMobileDemoRequestAuth(
 	const email = request.headers.get("x-mobile-student-email")?.trim().toLowerCase();
 	const inviteCode = request.headers.get("x-mobile-student-invite-code")?.trim().toUpperCase();
 
-	if (!requestAccessKey || requestAccessKey !== accessKey || !email || !inviteCode) {
+	if (!requestAccessKey || requestAccessKey !== accessKey || !email) {
+		return null;
+	}
+
+	const existingStudent = await db
+		.select({ id: students.id })
+		.from(students)
+		.where(eq(students.email, email))
+		.get();
+
+	if (existingStudent && !inviteCode) {
+		return {
+			userId: existingStudent.id,
+			isAuthenticated: true,
+		};
+	}
+
+	if (!inviteCode) {
 		return null;
 	}
 
@@ -97,7 +114,12 @@ async function getMobileDemoRequestAuth(
 		.get();
 
 	if (!classroom) {
-		return null;
+		return existingStudent
+			? {
+				userId: existingStudent.id,
+				isAuthenticated: true,
+			}
+			: null;
 	}
 
 	const matchedStudent = await db
@@ -116,11 +138,7 @@ async function getMobileDemoRequestAuth(
 	// Mobile demo access relies on a classroom code header. If a student row still
 	// points at an older classroom, repair the denormalized classroom fields so the
 	// rest of the student queries read the correct classroom immediately.
-	const staleStudent = await db
-		.select({ id: students.id })
-		.from(students)
-		.where(eq(students.email, email))
-		.get();
+	const staleStudent = existingStudent;
 
 	if (!staleStudent) {
 		return null;

--- a/mobileAppFrontend/app/(student)/(tabs)/profile.tsx
+++ b/mobileAppFrontend/app/(student)/(tabs)/profile.tsx
@@ -1,3 +1,4 @@
+import { router } from "expo-router";
 import { Alert, ScrollView, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { PrimaryButton } from "@/components/PrimaryButton";
@@ -68,7 +69,8 @@ export default function ProfileScreen() {
         <View style={styles.infoCard}>
           <InfoRow label="Төрөл" value="Сурагч" />
           <InfoRow label="Утас" value={student.phone} />
-          <InfoRow label="Анги" value={student.inviteCode} />
+          <InfoRow label="Анги" value={student.className} />
+          <InfoRow label="Ангийн код" value={student.inviteCode} />
         </View>
 
         <StatusCard
@@ -80,6 +82,13 @@ export default function ProfileScreen() {
           }
         />
 
+        <PrimaryButton
+          label="Анги солих"
+          onPress={() => {
+            router.push("/(student)/profile/classroom");
+          }}
+          variant="secondary"
+        />
         <PrimaryButton
           label={isRemoteData ? "Өгөгдөл шинэчлэх" : "Үр дүн цэвэрлэх"}
           onPress={handleReset}

--- a/mobileAppFrontend/app/(student)/_layout.tsx
+++ b/mobileAppFrontend/app/(student)/_layout.tsx
@@ -18,6 +18,7 @@ export default function StudentLayout() {
     <AppDataProvider>
       <Stack screenOptions={{ headerShown: false }}>
         <Stack.Screen name="(tabs)" />
+        <Stack.Screen name="profile/classroom" />
         <Stack.Screen name="exam/[examId]" />
         <Stack.Screen name="exam/submitted" />
         <Stack.Screen name="exam/[examId]/take" />

--- a/mobileAppFrontend/app/(student)/profile/classroom.tsx
+++ b/mobileAppFrontend/app/(student)/profile/classroom.tsx
@@ -1,0 +1,159 @@
+import { Stack, router } from "expo-router";
+import { useState } from "react";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { PrimaryButton } from "@/components/PrimaryButton";
+import { StatusCard } from "@/components/StatusCard";
+import { TextField } from "@/components/TextField";
+import { useAppData } from "@/data/app-data";
+import { colors, fonts, shadows } from "@/lib/theme";
+
+export default function ChangeClassroomScreen() {
+  const { student, changeStudentClassroom, isRemoteData } = useAppData();
+  const [inviteCode, setInviteCode] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleSave = async () => {
+    const normalizedCode = inviteCode.trim().toUpperCase();
+
+    if (!normalizedCode) {
+      setError("Ангийн кодоо оруулна уу.");
+      return;
+    }
+
+    setLoading(true);
+    setError("");
+
+    try {
+      await changeStudentClassroom(normalizedCode);
+      router.back();
+    } catch (caughtError) {
+      setError(caughtError instanceof Error ? caughtError.message : "Анги солиход алдаа гарлаа.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <SafeAreaView edges={["top", "left", "right"]} style={styles.page}>
+      <Stack.Screen options={{ headerShown: false }} />
+
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.title}>Анги солих</Text>
+        <Text style={styles.subtitle}>
+          Нэг сурагч нэг л ангид харьяалагдана. Шинэ код оруулбал одоогийн ангийг тань солино.
+        </Text>
+
+        <View style={styles.card}>
+          <InfoRow label="Одоогийн анги" value={student.className} />
+          <InfoRow label="Одоогийн код" value={student.inviteCode} isLast />
+        </View>
+
+        {!isRemoteData ? (
+          <StatusCard tone="warning" message="Энэ үйлдэл зөвхөн backend-тэй горимд ажиллана." />
+        ) : null}
+        {error ? <StatusCard tone="error" message={error} /> : null}
+
+        <View style={styles.formCard}>
+          <TextField
+            label="Шинэ ангийн код"
+            value={inviteCode}
+            onChangeText={setInviteCode}
+            autoCapitalize="characters"
+            autoCorrect={false}
+            placeholder="Жишээ: FTQ8W7"
+          />
+        </View>
+
+        <PrimaryButton
+          label="Хадгалах"
+          onPress={() => {
+            void handleSave();
+          }}
+          loading={loading}
+          disabled={!isRemoteData}
+        />
+        <PrimaryButton
+          label="Буцах"
+          onPress={() => {
+            router.back();
+          }}
+          variant="secondary"
+        />
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function InfoRow({ label, value, isLast = false }: { label: string; value: string; isLast?: boolean }) {
+  return (
+    <View style={[styles.infoRow, isLast ? styles.infoRowLast : null]}>
+      <Text style={styles.infoLabel}>{label}</Text>
+      <Text style={styles.infoValue}>{value}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  page: {
+    flex: 1,
+    backgroundColor: colors.pageBackground,
+  },
+  content: {
+    paddingHorizontal: 20,
+    paddingTop: 20,
+    paddingBottom: 120,
+  },
+  title: {
+    fontFamily: fonts.display.semibold,
+    fontSize: 28,
+    color: colors.textPrimary,
+  },
+  subtitle: {
+    marginTop: 10,
+    fontFamily: fonts.sans.regular,
+    fontSize: 15,
+    lineHeight: 22,
+    color: colors.textMuted,
+  },
+  card: {
+    marginTop: 18,
+    borderRadius: 24,
+    backgroundColor: colors.surface,
+    paddingHorizontal: 18,
+    paddingVertical: 8,
+    ...shadows.card,
+  },
+  infoRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  infoRowLast: {
+    borderBottomWidth: 0,
+  },
+  infoLabel: {
+    fontFamily: fonts.sans.medium,
+    fontSize: 14,
+    color: colors.textMuted,
+  },
+  infoValue: {
+    maxWidth: "58%",
+    textAlign: "right",
+    fontFamily: fonts.sans.semibold,
+    fontSize: 15,
+    color: colors.textPrimary,
+  },
+  formCard: {
+    marginTop: 16,
+    borderRadius: 24,
+    backgroundColor: colors.surface,
+    paddingHorizontal: 18,
+    paddingVertical: 18,
+    ...shadows.card,
+  },
+});

--- a/mobileAppFrontend/src/data/app-data.tsx
+++ b/mobileAppFrontend/src/data/app-data.tsx
@@ -13,6 +13,7 @@ import {
   saveRemoteSnapshot,
 } from "@/lib/app-storage";
 import {
+  changeRemoteStudentClassroom,
   fetchRemoteAvailableExams,
   fetchRemoteExamById,
   fetchRemoteStudentProfile,
@@ -38,6 +39,7 @@ type AppDataContextValue = {
   ensureExamLoaded: (examId: string) => Promise<Exam | null>;
   ensureSubmissionLoaded: (submissionId: string) => Promise<Submission | null>;
   refreshData: () => Promise<void>;
+  changeStudentClassroom: (inviteCode: string) => Promise<StudentProfile>;
   submitExam: (input: {
     examId: string;
     startedAt: number;
@@ -404,6 +406,21 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
     return { id: nextSubmission.id };
   }, [refreshRemoteSnapshot, submissions, useRemoteData]);
 
+  const changeStudentClassroom = useCallback<AppDataContextValue["changeStudentClassroom"]>(async (inviteCode) => {
+    if (!useRemoteData) {
+      throw new Error("Анги солих нь зөвхөн backend-тэй горимд ажиллана.");
+    }
+
+    const nextStudent = await changeRemoteStudentClassroom(inviteCode);
+    const snapshot = await pullRemoteSnapshot();
+    const mergedSnapshot = applyRemoteSnapshot({
+      ...snapshot,
+      student: nextStudent,
+    });
+    await saveRemoteSnapshot(mergedSnapshot);
+    return mergedSnapshot.student;
+  }, [applyRemoteSnapshot, pullRemoteSnapshot, useRemoteData]);
+
   const resetData = useCallback(() => {
     if (useRemoteData) {
       void (async () => {
@@ -431,6 +448,7 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
       ensureExamLoaded,
       ensureSubmissionLoaded,
       refreshData,
+      changeStudentClassroom,
       submitExam,
       resetData,
     }),
@@ -438,6 +456,7 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
       availableExams,
       ensureExamLoaded,
       ensureSubmissionLoaded,
+      changeStudentClassroom,
       getExamById,
       getSubmissionById,
       refreshData,

--- a/mobileAppFrontend/src/data/student-data.ts
+++ b/mobileAppFrontend/src/data/student-data.ts
@@ -8,6 +8,8 @@ export const studentProfile: StudentProfile = {
   email: "temuulen@school.mn",
   role: "student",
   phone: "99112233",
+  grade: "9",
+  className: "9А - Туршилтын анги",
   inviteCode: "9A-101",
 };
 

--- a/mobileAppFrontend/src/data/types.ts
+++ b/mobileAppFrontend/src/data/types.ts
@@ -66,5 +66,7 @@ export type StudentProfile = {
   email: string;
   role: "student";
   phone: string;
+  grade: string;
+  className: string;
   inviteCode: string;
 };

--- a/mobileAppFrontend/src/lib/app-storage.ts
+++ b/mobileAppFrontend/src/lib/app-storage.ts
@@ -86,6 +86,8 @@ function isStudentProfile(value: unknown): value is StudentProfile {
     typeof student.email === "string" &&
     student.role === "student" &&
     typeof student.phone === "string" &&
+    typeof student.grade === "string" &&
+    typeof student.className === "string" &&
     typeof student.inviteCode === "string"
   );
 }

--- a/mobileAppFrontend/src/lib/mobile-graphql.ts
+++ b/mobileAppFrontend/src/lib/mobile-graphql.ts
@@ -4,7 +4,7 @@ type MobileRemoteConfig = {
   graphqlUrl: string;
   accessKey: string;
   studentEmail: string;
-  studentInviteCode: string;
+  studentInviteCode?: string;
 };
 
 type GraphqlError = {
@@ -120,6 +120,10 @@ type SubmitStudentExamResponse = {
   submitStudentExam: {
     id: string;
   };
+};
+
+type ChangeStudentClassroomResponse = {
+  changeStudentClassroom: RemoteStudentProfile["studentById"];
 };
 
 const GET_CURRENT_STUDENT = `
@@ -240,6 +244,21 @@ const SUBMIT_STUDENT_EXAM = `
   }
 `;
 
+const CHANGE_STUDENT_CLASSROOM = `
+  mutation ChangeStudentClassroom($input: ChangeStudentClassroomInput!) {
+    changeStudentClassroom(input: $input) {
+      id
+      firstName
+      lastName
+      email
+      phone
+      grade
+      className
+      inviteCode
+    }
+  }
+`;
+
 const NETWORK_TIMEOUT_MS = 8_000;
 
 function readEnv(name: string) {
@@ -252,7 +271,7 @@ export function getMobileRemoteConfig(): MobileRemoteConfig | null {
   const studentEmail = readEnv("EXPO_PUBLIC_MOBILE_STUDENT_EMAIL").toLowerCase();
   const studentInviteCode = readEnv("EXPO_PUBLIC_MOBILE_STUDENT_INVITE_CODE").toUpperCase();
 
-  if (!graphqlUrl || !accessKey || !studentEmail || !studentInviteCode) {
+  if (!graphqlUrl || !accessKey || !studentEmail) {
     return null;
   }
 
@@ -260,7 +279,7 @@ export function getMobileRemoteConfig(): MobileRemoteConfig | null {
     graphqlUrl,
     accessKey,
     studentEmail,
-    studentInviteCode,
+    studentInviteCode: studentInviteCode || undefined,
   };
 }
 
@@ -285,7 +304,9 @@ async function fetchGraphql<TData>(query: string, variables?: Record<string, unk
         "Content-Type": "application/json",
         "x-mobile-demo-key": config.accessKey,
         "x-mobile-student-email": config.studentEmail,
-        "x-mobile-student-invite-code": config.studentInviteCode,
+        ...(config.studentInviteCode
+          ? { "x-mobile-student-invite-code": config.studentInviteCode }
+          : {}),
       },
       body: JSON.stringify({
         query,
@@ -330,6 +351,8 @@ function mapStudentProfile(payload: RemoteStudentProfile["studentById"]): Studen
     email: payload.email,
     role: "student",
     phone: payload.phone,
+    grade: payload.grade,
+    className: payload.className,
     inviteCode: payload.inviteCode,
   };
 }
@@ -463,4 +486,14 @@ export async function submitRemoteStudentExam(input: {
 }) {
   const payload = await fetchGraphql<SubmitStudentExamResponse>(SUBMIT_STUDENT_EXAM, { input });
   return payload.submitStudentExam;
+}
+
+export async function changeRemoteStudentClassroom(inviteCode: string) {
+  const payload = await fetchGraphql<ChangeStudentClassroomResponse>(CHANGE_STUDENT_CLASSROOM, {
+    input: {
+      inviteCode: inviteCode.trim().toUpperCase(),
+    },
+  });
+
+  return mapStudentProfile(payload.changeStudentClassroom);
 }

--- a/mobileAppFrontend/src/security/session-integrity.ts
+++ b/mobileAppFrontend/src/security/session-integrity.ts
@@ -105,7 +105,9 @@ function getSessionBackendConfig(): SessionBackendConfig | null {
       "Content-Type": "application/json",
       "x-mobile-demo-key": remoteConfig.accessKey,
       "x-mobile-student-email": remoteConfig.studentEmail,
-      "x-mobile-student-invite-code": remoteConfig.studentInviteCode,
+      ...(remoteConfig.studentInviteCode
+        ? { "x-mobile-student-invite-code": remoteConfig.studentInviteCode }
+        : {}),
     },
   };
 }


### PR DESCRIPTION
## Summary
Moved mobile student classroom assignment away from fixed `.env` invite-code configuration and added a DB-backed class-switch flow from the student profile screen.

## Why
Previously the mobile app depended on:
- `EXPO_PUBLIC_MOBILE_STUDENT_EMAIL`
- `EXPO_PUBLIC_MOBILE_STUDENT_INVITE_CODE`

This meant changing a student's classroom required editing env config and restarting the app. That is not suitable for real usage.

## Changes
- Added backend `changeStudentClassroom` mutation
- Kept the rule that one student belongs to one classroom at a time
- Updating classroom membership now rewrites the student's:
  - `classroomId`
  - `className`
  - `inviteCode`
  - `teacherId`
  - derived `grade`
- Updated mobile demo auth so it can resolve the current student by email even when invite code is not sent
- Made mobile invite code header optional in demo mode
- Added mobile profile UI to display:
  - current classroom
  - current class code
- Added a dedicated `Анги солих` screen under profile
- Added mobile client mutation helper to submit new class codes and refresh the current snapshot
- Extended student profile model on mobile with:
  - `grade`
  - `className`

## Backend files
- `cold-king-fc65/src/server.ts`
- `cold-king-fc65/src/graphql/schemas/student.schema.ts`
- `cold-king-fc65/src/graphql/resolvers/mutations/student.mutations.ts`

## Mobile files
- `mobileAppFrontend/src/data/types.ts`
- `mobileAppFrontend/src/data/student-data.ts`
- `mobileAppFrontend/src/lib/app-storage.ts`
- `mobileAppFrontend/src/lib/mobile-graphql.ts`
- `mobileAppFrontend/src/data/app-data.tsx`
- `mobileAppFrontend/src/security/session-integrity.ts`
- `mobileAppFrontend/app/(student)/(tabs)/profile.tsx`
- `mobileAppFrontend/app/(student)/profile/classroom.tsx`
- `mobileAppFrontend/app/(student)/_layout.tsx`

## Result
- Student classroom membership is now persisted in DB instead of being controlled only by `.env`
- Mobile users can change classroom from the profile area
- One student remains mapped to exactly one classroom at a time

## Validation
- `cd cold-king-fc65 && npx tsc --noEmit` passed
- `cd mobileAppFrontend && npx tsc --noEmit` passed
