### PR TITLE
Fix mobile classroom switching and active exam visibility for student…

### DIFF
--- a/cold-king-fc65/src/graphql/resolvers/student-exam.helpers.ts
+++ b/cold-king-fc65/src/graphql/resolvers/student-exam.helpers.ts
@@ -32,16 +32,18 @@ function parseScheduleDateTime(scheduledDate: string, startTime: string) {
 	const [, year, month, day] = dateMatch;
 	const [, hour, minute, second] = timeMatch;
 
-	// Announced exam times are entered for Ulaanbaatar local time, while the
-	// runtime may be in UTC. Convert the local wall time to a real timestamp.
+	// Announced exam times are entered as Ulaanbaatar wall time. Build the instant
+	// in UTC so visibility checks stay correct regardless of the worker runtime timezone.
 	const startsAt = new Date(
-		Number(year),
-		Number(month) - 1,
-		Number(day),
-		Number(hour) - ULAANBAATAR_UTC_OFFSET_HOURS,
-		Number(minute),
-		Number(second ?? '0'),
-		0,
+		Date.UTC(
+			Number(year),
+			Number(month) - 1,
+			Number(day),
+			Number(hour) - ULAANBAATAR_UTC_OFFSET_HOURS,
+			Number(minute),
+			Number(second ?? '0'),
+			0,
+		),
 	);
 
 	if (Number.isNaN(startsAt.getTime())) {

--- a/mobileAppFrontend/src/data/app-data.tsx
+++ b/mobileAppFrontend/src/data/app-data.tsx
@@ -21,6 +21,7 @@ import {
   fetchRemoteSubmissionById,
   fetchRemoteSubmissions,
   getMobileRemoteConfig,
+  setMobileStudentInviteCode,
   submitRemoteStudentExam,
 } from "@/lib/mobile-graphql";
 
@@ -156,6 +157,8 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const applyRemoteSnapshot = useCallback((snapshot: RemoteSnapshot) => {
+    setMobileStudentInviteCode(snapshot.student.inviteCode);
+
     const mergedSnapshot: RemoteSnapshot = {
       student: snapshot.student,
       availableExams: mergeExamCache(remoteAvailableExamsRef.current, snapshot.availableExams),
@@ -442,6 +445,7 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
     }
 
     const nextStudent = await changeRemoteStudentClassroom(inviteCode);
+    setMobileStudentInviteCode(nextStudent.inviteCode);
     const snapshot = await pullRemoteSnapshot();
     const mergedSnapshot = applyRemoteSnapshot({
       ...snapshot,

--- a/mobileAppFrontend/src/lib/mobile-graphql.ts
+++ b/mobileAppFrontend/src/lib/mobile-graphql.ts
@@ -7,6 +7,8 @@ type MobileRemoteConfig = {
   studentInviteCode?: string;
 };
 
+let runtimeStudentInviteCode: string | null = null;
+
 type GraphqlError = {
   message?: string;
 };
@@ -305,11 +307,17 @@ function readEnv(name: string) {
   return process.env[name]?.trim() ?? "";
 }
 
+export function setMobileStudentInviteCode(inviteCode?: string | null) {
+  const normalizedInviteCode = inviteCode?.trim().toUpperCase() ?? "";
+  runtimeStudentInviteCode = normalizedInviteCode || null;
+}
+
 export function getMobileRemoteConfig(): MobileRemoteConfig | null {
   const graphqlUrl = readEnv("EXPO_PUBLIC_GRAPHQL_URL");
   const accessKey = readEnv("EXPO_PUBLIC_MOBILE_DEMO_ACCESS_KEY");
   const studentEmail = readEnv("EXPO_PUBLIC_MOBILE_STUDENT_EMAIL").toLowerCase();
-  const studentInviteCode = readEnv("EXPO_PUBLIC_MOBILE_STUDENT_INVITE_CODE").toUpperCase();
+  const studentInviteCode =
+    runtimeStudentInviteCode ?? readEnv("EXPO_PUBLIC_MOBILE_STUDENT_INVITE_CODE").toUpperCase();
 
   if (!graphqlUrl || !accessKey || !studentEmail) {
     return null;


### PR DESCRIPTION
## Summary

Student-side mobile exam visibility was inconsistent after recent testing.

Two related problems were identified:

1. Changing the student's classroom in the app did not fully stick across subsequent requests.
2. Exams that should have appeared as active were sometimes filtered out incorrectly.

As a result, a teacher could schedule an exam, but the student app would still not show it in the expected tab.

## Root Cause

- The mobile app kept sending the invite code from environment config on every request, even after the user changed classrooms in-app.
- The backend exam visibility helper parsed scheduled date/time in a way that depended on the worker runtime timezone, which caused active exam windows to shift incorrectly.

## Changes

- Add runtime invite-code state in the mobile GraphQL client so request headers can follow the latest classroom selection.
- Update the app data flow to refresh and persist the current invite code from remote snapshot data and classroom-change actions.
- Fix student exam schedule parsing to construct the exam instant in a timezone-safe way for Ulaanbaatar wall time.

## Affected Files

- `mobileAppFrontend/src/lib/mobile-graphql.ts`
- `mobileAppFrontend/src/data/app-data.tsx`
- `cold-king-fc65/src/graphql/resolvers/student-exam.helpers.ts`

## Expected Result

- After changing classroom in the student app, all later requests use the new classroom code.
- Scheduled exams for the selected classroom appear in the correct student view.
- Exams move into the `active` list correctly when they enter the allowed visibility window.
- Active exam visibility is no longer affected by the backend runtime timezone.

## Acceptance Criteria

- Changing classroom in the mobile app updates downstream fetches immediately.
- A teacher-scheduled exam for the selected classroom appears on the student side without reverting to the previous classroom.
- Future exams appear under scheduled.
- Exams within the active window appear under active.
- No regression in remote snapshot loading or exam cache merging.

## Verification

- `cd mobileAppFrontend && npm run typecheck`
- `cd cold-king-fc65 && npx tsc --noEmit`
- Manual test on physical iPhone:
  - change classroom in app
  - refresh student home
  - verify exam appears under the correct tab
  - verify active exam becomes visible at the correct time
